### PR TITLE
Release alpha3: disable menu access

### DIFF
--- a/app/app.c
+++ b/app/app.c
@@ -1400,6 +1400,20 @@ static void APP_ProcessKey(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 		return;
 	}
 
+	if (Key == KEY_MENU) {
+		if (!bKeyPressed) {
+			return;
+		}
+		if (gWasFKeyPressed) {
+			gWasFKeyPressed = false;
+			gUpdateStatus = true;
+		}
+		if (!bKeyHeld) {
+			gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
+		}
+		goto Skip;
+	}
+
 	bFlag = false;
 
 	if (gPttWasPressed && Key == KEY_PTT) {

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -5,6 +5,7 @@ ROOT="/app"
 ARTIFACT_DIR="${ROOT}/compiled-firmware"
 
 mkdir -p "${ARTIFACT_DIR}"
+rm -f "${ARTIFACT_DIR}"/loaner-firmware*.bin
 
 echo "Running cppcheck lint..."
 cppcheck \

--- a/compile-with-docker.sh
+++ b/compile-with-docker.sh
@@ -7,6 +7,8 @@ IMAGE_TAG="uvk5-loaner"
 
 mkdir -p "${OUT_DIR}"
 
+rm -f "${OUT_DIR}"/loaner-firmware*.bin
+
 docker build -t "${IMAGE_TAG}" "${SCRIPT_DIR}"
 
 docker run --rm \

--- a/docs/releases/LNR24A3.md
+++ b/docs/releases/LNR24A3.md
@@ -1,0 +1,11 @@
+## Loaner Firmware Alpha 3 – LNR24A3
+
+- Disable the physical Menu key so accidental presses no longer expose configuration menus.
+- Clean build scripts to drop stale `loaner-firmware*.bin` artifacts before each Docker build, ensuring releases only contain fresh images.
+
+Tag this build as `v24.10-alpha3` and publish the two artifacts below.
+
+Artifacts generated via `./compile-with-docker.sh`:
+
+- `compiled-firmware/loaner-firmware-LNR24A3.bin`
+- `compiled-firmware/loaner-firmware-LNR24A3.packed.bin`


### PR DESCRIPTION
- Disable Menu key processing so radios stay in locked menu-less mode.
- Clean build scripts by deleting prior loaner firmware artifacts before each Docker build.
- Document alpha release LNR24A3 with artifact paths and tagging guidance.

Testing:
- ./compile-with-docker.sh

Closes #4