### PR TITLE
Force channel-name display on main screen

### DIFF
--- a/board.c
+++ b/board.c
@@ -526,7 +526,7 @@ void BOARD_EEPROM_Init(void)
 
 	// 0E78..0E7F
 	EEPROM_ReadBuffer(0x0E78, Data, 8);
-	gEeprom.CHANNEL_DISPLAY_MODE  = (Data[1] < 3) ? Data[1] : MDF_FREQUENCY;
+	gEeprom.CHANNEL_DISPLAY_MODE  = MDF_NAME;
 	gEeprom.CROSS_BAND_RX_TX      = (Data[2] < 3) ? Data[2] : CROSS_BAND_OFF;
 	gEeprom.BATTERY_SAVE          = (Data[3] < 5) ? Data[3] : 4;
 	gEeprom.DUAL_WATCH            = (Data[4] < 3) ? Data[4] : DUAL_WATCH_CHAN_A;

--- a/docs/releases/LNR24A4.md
+++ b/docs/releases/LNR24A4.md
@@ -1,0 +1,9 @@
+## Loaner Firmware Alpha 4 – LNR24A4
+
+- Force MR channels to render names (or the `CH-###` fallback) on the main screen so end users no longer see raw transmit frequencies.
+- Default new boots to name display mode (`MDF_NAME`) regardless of prior EEPROM values, keeping radios aligned with the locked channel-only experience.
+
+Artifacts generated via `./compile-with-docker.sh`:
+
+- `compiled-firmware/loaner-firmware-LNR24A4.bin`
+- `compiled-firmware/loaner-firmware-LNR24A4.packed.bin`

--- a/ui/main.c
+++ b/ui/main.c
@@ -236,7 +236,7 @@ void UI_DisplayMain(void)
 			if (gInputBoxIndex && IS_FREQ_CHANNEL(gEeprom.ScreenChannel[i]) && gEeprom.TX_VFO == i) {
 				UI_DisplayFrequency(gInputBox, 31, i * 4, true, false);
 			} else {
-				if (!IS_MR_CHANNEL(gEeprom.ScreenChannel[i]) || gEeprom.CHANNEL_DISPLAY_MODE == MDF_FREQUENCY) {
+				if (!IS_MR_CHANNEL(gEeprom.ScreenChannel[i])) {
 					if (gCurrentFunction == FUNCTION_TRANSMIT) {
 						if (gEeprom.CROSS_BAND_RX_TX == CROSS_BAND_OFF) {
 							Channel = gEeprom.RX_VFO;
@@ -262,16 +262,16 @@ void UI_DisplayMain(void)
 						}
 					}
 					UI_DisplaySmallDigits(2, String + 6, 112, Line + 1);
-				} else if (gEeprom.CHANNEL_DISPLAY_MODE == MDF_CHANNEL) {
-					sprintf(String, "CH-%03d", gEeprom.ScreenChannel[i] + 1);
-					UI_PrintString(String, 31, 112, i * 4, 8, true);
-				} else if (gEeprom.CHANNEL_DISPLAY_MODE == MDF_NAME) {
-					if(gEeprom.VfoInfo[i].Name[0] == 0 || gEeprom.VfoInfo[i].Name[0] == 0xFF) {
+				} else {
+					const char *pName = gEeprom.VfoInfo[i].Name;
+					if (pName[0] == 0 || pName[0] == (char)0xFF) {
 						sprintf(String, "CH-%03d", gEeprom.ScreenChannel[i] + 1);
 						UI_PrintString(String, 31, 112, i * 4, 8, true);
 					} else {
-						UI_PrintString(gEeprom.VfoInfo[i].Name, 31, 112, i * 4, 8, true);
+						UI_PrintString(pName, 31, 112, i * 4, 8, true);
 					}
+					NUMBER_ToDigits(gEeprom.ScreenChannel[i] + 1, String);
+					UI_DisplaySmallDigits(3, String + 5, 112, Line + 1);
 				}
 			}
 		}
@@ -377,4 +377,3 @@ void UI_DisplayMain(void)
 
 	ST7565_BlitFullScreen();
 }
-


### PR DESCRIPTION
- Default CHANNEL_DISPLAY_MODE to MDF_NAME so loaner radios always boot with names instead of frequencies.
- Render MR entries on the main screen using their stored name (falling back to CH-###) while still showing channel numbers in the small digit slot.
- Document the alpha 4 (LNR24A4) drop with the relevant artifacts.

Testing:
- ./compile-with-docker.sh

Closes #7