### PR TITLE
Allow release workflow to update existing tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,3 +34,5 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: "compiled-firmware/loaner-firmware*.bin"
+          allowUpdates: true
+          prerelease: true


### PR DESCRIPTION
- Mark releases as prereleases and permit updates so the workflow stops failing when a tag already has a release.
- Keeps artifact uploads intact while letting us tweak release notes manually if needed.

Testing:
- Not run (workflow change)],