### PR TITLE
Switch side buttons to direct VFO select

### DIFF
--- a/docs/releases/LNR24A5.md
+++ b/docs/releases/LNR24A5.md
@@ -1,0 +1,9 @@
+## Loaner Firmware Alpha 5 – LNR24A5
+
+- Map the upper and lower side buttons directly to VFO A and VFO B selection, replacing the old configurable actions.
+- Reset dual watch/cross-band overrides when switching so each press reliably focuses the requested channel and announces it via voice prompts.
+
+Artifacts generated via `./compile-with-docker.sh`:
+
+- `compiled-firmware/loaner-firmware-LNR24A5.bin`
+- `compiled-firmware/loaner-firmware-LNR24A5.packed.bin`


### PR DESCRIPTION
- Replace the configurable side-key actions with deterministic VFO picks: upper button selects VFO A, lower selects VFO B.
- Reset cross-band/dual-watch overrides and announce the chosen channel so loaners always focus the intended memory slot.
- Document alpha5 (LNR24A5) with updated artifact names.

Testing:
- ./compile-with-docker.sh

Closes #15