### PR TITLE
Tighten CI versioning workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      version_suffix:
+        description: 'Release VERSION_SUFFIX (e.g. LNR24B1). Required when manually triggering.'
+        required: false
 
 jobs:
   build:
@@ -18,6 +23,18 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Derive version suffix
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ -z "${{ github.event.inputs.version_suffix }}" ]]; then
+              echo "VERSION_SUFFIX input is required when running manually" >&2
+              exit 1
+            fi
+            echo "VERSION_SUFFIX=${{ github.event.inputs.version_suffix }}" >> "$GITHUB_ENV"
+          else
+            echo "VERSION_SUFFIX=CI${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+          fi
+
       - name: Build firmware (Docker)
         run: ./compile-with-docker.sh
 
@@ -26,6 +43,7 @@ jobs:
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
+        if: github.event_name == 'workflow_dispatch'
         with:
           name: loaner-firmware
           path: compiled-firmware/loaner-firmware*.bin

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,8 +14,68 @@ on:
         required: false
 
 jobs:
+  style:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install linters
+        run: |
+          python -m pip install --upgrade pip ruff==0.5.6
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Ruff (pyflakes)
+        run: python -m ruff check fw-pack.py tests
+
+      - name: Shellcheck
+        run: shellcheck compile-with-docker.sh ci/run.sh
+
+  cppcheck:
+    runs-on: ubuntu-22.04
+    needs: style
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install cppcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cppcheck
+
+      - name: Run cppcheck
+        run: CI_MODE=cppcheck ./ci/run.sh
+
+  python-tests:
+    runs-on: ubuntu-22.04
+    needs: [style, cppcheck]
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.12']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip pytest crcmod
+
+      - name: Run pytest
+        run: pytest -q
+
   build:
     runs-on: ubuntu-22.04
+    needs: [python-tests, cppcheck]
 
     steps:
       - name: Checkout

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,2 @@
+target-version = "py312"
+select = ["F", "E9"]

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -11,7 +11,7 @@ This document walks through producing firmware binaries locally or inside the pr
 
 1. From the repository root:
    ```sh
-   ./compile-with-docker.sh
+   VERSION_SUFFIX=LNR24B1 ./compile-with-docker.sh
    ```
 2. The script builds the Docker image, runs `ci/run.sh` inside the container (cppcheck + pytest + firmware build), and drops artifacts to `compiled-firmware/` on your host:
    - `compiled-firmware/loaner-firmware.bin`
@@ -20,7 +20,7 @@ This document walks through producing firmware binaries locally or inside the pr
 If the script fails, inspect the console output; lint or unit test failures abort the build so issues are caught before you publish a release.
 
 ## Native Build (optional)
-When you already have the toolchain locally, you can mirror the Docker steps:
+Docker remains the preferred path. Only follow these steps if you must build locally with an existing toolchain:
 
 1. Clean previous objects:
    ```sh
@@ -32,15 +32,15 @@ When you already have the toolchain locally, you can mirror the Docker steps:
    ```
    The above command produces `loaner-firmware.bin`. If Python with `crcmod` is installed you will also get `loaner-firmware.packed.bin`.  
    If you omit `TARGET=...` the files are named `firmware.bin` / `firmware.packed.bin`.
-   The build also exports `VERSION_SUFFIX` into the binaries. Set it explicitly (for example `make TARGET=loaner-firmware VERSION_SUFFIX=LNR24A5`) or create an `LNR*` git tag that the Makefile can discover. The build errors out if neither is present.
+   The build also exports `VERSION_SUFFIX` into the binaries. Set it explicitly (for example `make TARGET=loaner-firmware VERSION_SUFFIX=LNR24B1`) or create an `LNR*` git tag that the Makefile can discover. The build errors out if neither is present.
 
 ## Creating a Packed Binary Manually
 If the packed image was not produced automatically (for example on a minimal native setup), run:
 ```sh
-python3 fw-pack.py loaner-firmware.bin LNR24.03 loaner-firmware.packed.bin
+python3 fw-pack.py loaner-firmware.bin LNR24B1 loaner-firmware.packed.bin
 ```
 
-- The second argument is the version tag embedded in both the welcome screen and the packed metadata (mirror the `VERSION_SUFFIX` you build with).  
+- Replace `LNR24B1` with the same suffix you pass in via `VERSION_SUFFIX`. That value is embedded in both the welcome screen and the packed metadata.  
   Keep it under 10 ASCII characters (the script rejects longer strings).
 - The packed image is required for PC loader flashing because it carries the metadata Quansheng's tool expects.
 
@@ -61,14 +61,44 @@ Feature flags live near the top of `Makefile` as `ENABLE_*` macros. Adjust them 
 
 ## Firmware Metadata and Releases
 - A successful build leaves you with `firmware.bin` (raw) and, when Python and `crcmod` are available, `firmware.packed.bin`. The packed image is what Quansheng's loader validates.
-- Use `fw-pack.py` to stamp a release tag into the packed image. `make` already invokes the script with `VERSION_SUFFIX`, so the packed file inherits the same banner. To repack manually, pass the suffix yourself:
+- Use `fw-pack.py` to stamp a release tag into the packed image. `make` already invokes the script with `VERSION_SUFFIX`, so the packed file inherits the same banner. To repack manually, pass the suffix yourself (example above).
+- When building outside of Docker, set `VERSION_SUFFIX` in your environment once (for example `export VERSION_SUFFIX=LNR24B1`) so every command picks up the same value.  
+  For Docker builds, prefix the wrapper with the same variable:  
   ```sh
-  python3 fw-pack.py firmware.bin "${VERSION_SUFFIX}" loaner-firmware.packed.bin
+  VERSION_SUFFIX=LNR24B1 ./compile-with-docker.sh
   ```
-- When building outside of Docker, set `VERSION_SUFFIX` in your environment once (for example `export VERSION_SUFFIX=LNR24A5`) so every command picks up the same value.
 - Change the `TARGET` on the `make` command line to tweak the output filenames without editing source, for example `make TARGET=loaner-firmware`.
 - Before publishing a release, spot-check the welcome screen on hardware to make sure the tag matches what you intend to share with end users.
-- Recommended version format: mirror other UV-K5 firmware projects (Quansheng's stock firmware ships as `v2.1.27`, Open Edition uses `OEFW-2023.09`). Tag milestones as `vYY.MM[.PATCH]` and feed a matching, <=10 character `VERSION_SUFFIX` (for example `LNR24.03`). CHIRP reads the full `*OEFW-LNR24.03` banner and treats it as a known build.
+- Recommended version format: mirror other UV-K5 firmware projects (Quansheng's stock firmware ships as `v2.1.27`, Open Edition uses `OEFW-2023.09`). Tag milestones as `vYY.MM[.PATCH]` and feed a matching, <=10 character `VERSION_SUFFIX` (for example `LNR24B1`). CHIRP reads the full `*OEFW-LNR24B1` banner and treats it as a known build.
+
+## Release Versioning Checklist
+Follow this sequence for every tagged release:
+
+1. **Pick a suffix**: Choose a 10-character-or-shorter identifier in the form `LNRYYxN` (for example `LNR24B1`). The suffix should line up with the git tag you plan to publish (for example `v24.12`).
+2. **Export the suffix** so every build step sees the same value:
+   ```sh
+   export VERSION_SUFFIX=LNR24B1
+   ```
+   (Or prefix individual commands with `VERSION_SUFFIX=...` if you prefer.)
+3. **Build and test** (Docker path preferred):
+   ```sh
+   VERSION_SUFFIX=LNR24B1 ./compile-with-docker.sh
+   ```
+   This reproduces the CI pipeline (cppcheck + pytest + firmware build) and drops `compiled-firmware/loaner-firmware-LNR24B1.bin/.packed.bin`.  
+   If you must build natively, run:
+   ```sh
+   make clean
+   make TARGET=loaner-firmware VERSION_SUFFIX=LNR24B1
+   pytest -q
+   ```
+4. **Validate on hardware**: Flash the packed image and confirm the radio splash reports `OEFW-LNR24B1`.
+5. **Tag the release** using the calendar semantic scheme:
+   ```sh
+   git tag -a v24.12 -m "Loaner firmware v24.12"
+   git push origin v24.12
+   ```
+6. **Publish the GitHub release**: Attach the packed binary (`compiled-firmware/loaner-firmware-LNR24B1.packed.bin`) and include the validation steps in the notes. If you prefer CI-generated artifacts, trigger the `CI` workflow manually via “Run workflow” in GitHub and supply `LNR24B1` as the `version_suffix`; the workflow only uploads artifacts on manual runs.
+7. **Upstream tooling**: When the suffix changes, update any dependent projects (for example CHIRP PR #1414) so they whitelist the new `OEFW-LNR` banner.
 
 ## Branching and Release Flow
 1. Start work on a fresh branch instead of `main`:

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT="/app"
 ARTIFACT_DIR="${ROOT}/compiled-firmware"
 
+: "${VERSION_SUFFIX:?VERSION_SUFFIX is required (set VERSION_SUFFIX=LNR24B1 before running this script)}"
+
 mkdir -p "${ARTIFACT_DIR}"
 rm -f "${ARTIFACT_DIR}"/loaner-firmware*.bin
 

--- a/compile-with-docker.sh
+++ b/compile-with-docker.sh
@@ -5,6 +5,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 OUT_DIR="${SCRIPT_DIR}/compiled-firmware"
 IMAGE_TAG="uvk5-loaner"
 
+if [[ -z "${VERSION_SUFFIX:-}" ]]; then
+  echo "VERSION_SUFFIX must be set (e.g. VERSION_SUFFIX=LNR24B1 ./compile-with-docker.sh)" >&2
+  exit 1
+fi
+
 mkdir -p "${OUT_DIR}"
 
 rm -f "${OUT_DIR}"/loaner-firmware*.bin
@@ -13,5 +18,6 @@ docker build -t "${IMAGE_TAG}" "${SCRIPT_DIR}"
 
 docker run --rm \
   -v "${OUT_DIR}":/app/compiled-firmware \
+  -e VERSION_SUFFIX="${VERSION_SUFFIX}" \
   "${IMAGE_TAG}" \
   /bin/bash -lc "cd /app && chmod +x ci/run.sh && ./ci/run.sh"

--- a/driver/gpio.c
+++ b/driver/gpio.c
@@ -21,7 +21,7 @@ void GPIO_ClearBit(volatile uint32_t *pReg, uint8_t Bit)
 	*pReg &= ~(1U << Bit);
 }
 
-uint8_t GPIO_CheckBit(volatile uint32_t *pReg, uint8_t Bit)
+uint8_t GPIO_CheckBit(volatile const uint32_t *pReg, uint8_t Bit)
 {
 	return (*pReg >> Bit) & 1U;
 }
@@ -35,4 +35,3 @@ void GPIO_SetBit(volatile uint32_t *pReg, uint8_t Bit)
 {
 	*pReg |= 1U << Bit;
 }
-

--- a/driver/gpio.h
+++ b/driver/gpio.h
@@ -61,9 +61,8 @@ enum GPIOC_PINS {
 };
 
 void GPIO_ClearBit(volatile uint32_t *pReg, uint8_t Bit);
-uint8_t GPIO_CheckBit(volatile uint32_t *pReg, uint8_t Bit);
+uint8_t GPIO_CheckBit(volatile const uint32_t *pReg, uint8_t Bit);
 void GPIO_FlipBit(volatile uint32_t *pReg, uint8_t Bit);
 void GPIO_SetBit(volatile uint32_t *pReg, uint8_t Bit);
 
 #endif
-

--- a/fw-pack.py
+++ b/fw-pack.py
@@ -4,7 +4,6 @@ import crcmod
 import sys
 
 from itertools import cycle
-from binascii import hexlify
 
 OBFUSCATION = [
         0x47, 0x22, 0xC0, 0x52, 0x5D, 0x57, 0x48, 0x94, 0xB1, 0x60, 0x60, 0xDB, 0x6F, 0xE3, 0x4C, 0x7C,
@@ -37,4 +36,3 @@ digest = crc.digest()
 digest = bytes([digest[1], digest[0]])
 
 open(sys.argv[3], 'wb').write(packed + digest)
-

--- a/misc.c
+++ b/misc.c
@@ -163,7 +163,7 @@ uint8_t gIsLocked = 0xFF;
 
 // --------
 
-void NUMBER_Get(char *pDigits, uint32_t *pInteger)
+void NUMBER_Get(const char *pDigits, uint32_t *pInteger)
 {
 	uint32_t Value;
 	uint32_t Multiplier;
@@ -206,4 +206,3 @@ uint8_t NUMBER_AddWithWraparound(uint8_t Base, int8_t Add, uint8_t LowerLimit, u
 
 	return Base;
 }
-

--- a/misc.h
+++ b/misc.h
@@ -219,9 +219,8 @@ extern uint8_t gIsLocked;
 
 // --------
 
-void NUMBER_Get(char *pDigits, uint32_t *pInteger);
+void NUMBER_Get(const char *pDigits, uint32_t *pInteger);
 void NUMBER_ToDigits(uint32_t Value, char *pDigits);
 uint8_t NUMBER_AddWithWraparound(uint8_t Base, int8_t Add, uint8_t LowerLimit, uint8_t UpperLimit);
 
 #endif
-


### PR DESCRIPTION
## Summary
- add style gate running ruff (pyflakes) over fw-pack.py/tests and shellcheck on scripts
- run pytest on both Python 3.10 and 3.12 before building Docker firmware
- document branch + release workflow and VERSION_SUFFIX usage so manual/CI builds stay aligned

## Testing
- not run (CI-only change)
