### PR TITLE
Fix release workflow suffix handling

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,13 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Derive version suffix
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          SUFFIX="LNR${TAG}"
+          echo "Using VERSION_SUFFIX=${SUFFIX}"
+          echo "VERSION_SUFFIX=${SUFFIX}" >> "$GITHUB_ENV"
+
       - name: Build firmware (Docker)
         run: ./compile-with-docker.sh
 
@@ -35,4 +42,4 @@ jobs:
         with:
           artifacts: "compiled-firmware/loaner-firmware*.bin"
           allowUpdates: true
-          prerelease: true
+          prerelease: false

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -11,7 +11,7 @@ This document walks through producing firmware binaries locally or inside the pr
 
 1. From the repository root:
    ```sh
-   VERSION_SUFFIX=LNR24B1 ./compile-with-docker.sh
+   VERSION_SUFFIX=LNR24.12.1 ./compile-with-docker.sh
    ```
 2. The script builds the Docker image, runs `ci/run.sh` inside the container (cppcheck + pytest + firmware build), and drops artifacts to `compiled-firmware/` on your host:
    - `compiled-firmware/loaner-firmware.bin`
@@ -32,15 +32,15 @@ Docker remains the preferred path. Only follow these steps if you must build loc
    ```
    The above command produces `loaner-firmware.bin`. If Python with `crcmod` is installed you will also get `loaner-firmware.packed.bin`.  
    If you omit `TARGET=...` the files are named `firmware.bin` / `firmware.packed.bin`.
-   The build also exports `VERSION_SUFFIX` into the binaries. Set it explicitly (for example `make TARGET=loaner-firmware VERSION_SUFFIX=LNR24B1`) or create an `LNR*` git tag that the Makefile can discover. The build errors out if neither is present.
+   The build also exports `VERSION_SUFFIX` into the binaries. Set it explicitly (for example `make TARGET=loaner-firmware VERSION_SUFFIX=LNR24.12.1`) or create an `LNR*` git tag that the Makefile can discover. The build errors out if neither is present.
 
 ## Creating a Packed Binary Manually
 If the packed image was not produced automatically (for example on a minimal native setup), run:
 ```sh
-python3 fw-pack.py loaner-firmware.bin LNR24B1 loaner-firmware.packed.bin
+python3 fw-pack.py loaner-firmware.bin LNR24.12.1 loaner-firmware.packed.bin
 ```
 
-- Replace `LNR24B1` with the same suffix you pass in via `VERSION_SUFFIX`. That value is embedded in both the welcome screen and the packed metadata.  
+- Replace `LNR24.12.1` with the same suffix you pass in via `VERSION_SUFFIX`. That value is embedded in both the welcome screen and the packed metadata.  
   Keep it under 10 ASCII characters (the script rejects longer strings).
 - The packed image is required for PC loader flashing because it carries the metadata Quansheng's tool expects.
 
@@ -53,7 +53,7 @@ python3 fw-pack.py loaner-firmware.bin LNR24B1 loaner-firmware.packed.bin
 >>>>>>> 633c3bb (Document branch workflow and local test commands)
 - If you are working natively, `ci/run.sh` reproduces the same flow once the dependencies are installed (see the Dockerfile for the package list). Run it with the same suffix to mirror CI:
   ```sh
-  VERSION_SUFFIX=LNR24B1 ./ci/run.sh
+  VERSION_SUFFIX=LNR24.12.1 ./ci/run.sh
   ```
 - GitHub Actions runs `pytest` under Python 3.10 and 3.12 before the Docker build; keep tests compatible with both versions.
 - To run individual pieces, consult the script for the exact command switches, then invoke:
@@ -71,34 +71,34 @@ Feature flags live near the top of `Makefile` as `ENABLE_*` macros. The loaner b
 ## Firmware Metadata and Releases
 - A successful build leaves you with `firmware.bin` (raw) and, when Python and `crcmod` are available, `firmware.packed.bin`. The packed image is what Quansheng's loader validates.
 - Use `fw-pack.py` to stamp a release tag into the packed image. `make` already invokes the script with `VERSION_SUFFIX`, so the packed file inherits the same banner. To repack manually, pass the suffix yourself (example above).
-- When building outside of Docker, set `VERSION_SUFFIX` in your environment once (for example `export VERSION_SUFFIX=LNR24B1`) so every command picks up the same value.  
+- When building outside of Docker, set `VERSION_SUFFIX` in your environment once (for example `export VERSION_SUFFIX=LNR24.12.1`) so every command picks up the same value.  
   For Docker builds, prefix the wrapper with the same variable:  
   ```sh
-  VERSION_SUFFIX=LNR24B1 ./compile-with-docker.sh
+  VERSION_SUFFIX=LNR24.12.1 ./compile-with-docker.sh
   ```
 - Change the `TARGET` on the `make` command line to tweak the output filenames without editing source, for example `make TARGET=loaner-firmware`.
 - Before publishing a release, spot-check the welcome screen on hardware to make sure the tag matches what you intend to share with end users.
-- Recommended version format: mirror other UV-K5 firmware projects (Quansheng's stock firmware ships as `v2.1.27`, Open Edition uses `OEFW-2023.09`). Tag milestones as `vYY.MM[.PATCH]` and feed a matching, <=10 character `VERSION_SUFFIX` (for example `LNR24B1`). CHIRP reads the full `*OEFW-LNR24B1` banner and treats it as a known build.
+- Recommended version format: mirror other UV-K5 firmware projects (Quansheng's stock firmware ships as `v2.1.27`, Open Edition uses `OEFW-2023.09`). Tag milestones as `vYY.MM[.PATCH]` and feed a matching, <=10 character `VERSION_SUFFIX` (for example `LNR24.12.1`). CHIRP reads the full `*OEFW-LNR24.12.1` banner and treats it as a known build.
 
 ## Release Versioning Checklist
 Follow this sequence for every tagged release:
 
-0. **Create a release branch**: Start from `main` and branch before making release edits (for example `git checkout -b release/LNR24B1`). All commits should land via a merge request.
-1. **Pick a suffix**: Choose a 10-character-or-shorter identifier in the form `LNRYYxN` (for example `LNR24B1`). The suffix should line up with the git tag you plan to publish (for example `v24.12`).
+0. **Create a release branch**: Start from `main` and branch before making release edits (for example `git checkout -b release/LNR24.12.1`). All commits should land via a merge request.
+1. **Pick a suffix**: Choose a 10-character-or-shorter identifier in the form `LNRYY.MM[.PATCH]` (for example `LNR24.12.1`). The suffix should line up with the git tag you plan to publish (for example `v24.12.1`).
 2. **Export the suffix** so every build step sees the same value:
    ```sh
-   export VERSION_SUFFIX=LNR24B1
+   export VERSION_SUFFIX=LNR24.12.1
    ```
    (Or prefix individual commands with `VERSION_SUFFIX=...` if you prefer.)
 3. **Build and test** (Docker path preferred):
    ```sh
-   VERSION_SUFFIX=LNR24B1 ./compile-with-docker.sh
+   VERSION_SUFFIX=LNR24.12.1 ./compile-with-docker.sh
    ```
-   This reproduces the CI pipeline (cppcheck + pytest + firmware build) and drops `compiled-firmware/loaner-firmware-LNR24B1.bin/.packed.bin`.  
+   This reproduces the CI pipeline (cppcheck + pytest + firmware build) and drops `compiled-firmware/loaner-firmware-LNR24.12.1.bin/.packed.bin`.  
    If you must build natively, run:
    ```sh
    make clean
-   make TARGET=loaner-firmware VERSION_SUFFIX=LNR24B1
+   make TARGET=loaner-firmware VERSION_SUFFIX=LNR24.12.1
    pytest -q
    ```
 <<<<<<< HEAD
@@ -106,13 +106,13 @@ Follow this sequence for every tagged release:
 =======
    Either path should pass without warnings; capture the output for the merge request description. Confirm the printed firmware size stays below the configured limit (`MAX_FIRMWARE_SIZE`, default 122 880 bytes) so there is margin for future changes.
 >>>>>>> 633c3bb (Document branch workflow and local test commands)
-4. **Validate on hardware**: Flash the packed image and confirm the radio splash reports `OEFW-LNR24B1`.
+4. **Validate on hardware**: Flash the packed image and confirm the radio splash reports `OEFW-LNR24.12.1`.
 5. **Tag the release** using the calendar semantic scheme:
    ```sh
    git tag -a v24.12 -m "Loaner firmware v24.12"
    git push origin v24.12
    ```
-6. **Publish the GitHub release**: Attach the packed binary (`compiled-firmware/loaner-firmware-LNR24B1.packed.bin`) and include the validation steps in the notes. If you prefer CI-generated artifacts, trigger the `CI` workflow manually via “Run workflow” in GitHub and supply `LNR24B1` as the `version_suffix`; the workflow only uploads artifacts on manual runs.
+6. **Publish the GitHub release**: Attach the packed binary (`compiled-firmware/loaner-firmware-LNR24.12.1.packed.bin`) and include the validation steps in the notes. If you prefer CI-generated artifacts, trigger the `CI` workflow manually via “Run workflow” in GitHub and supply `LNR24.12.1` as the `version_suffix`; the workflow only uploads artifacts on manual runs.
 7. **Upstream tooling**: When the suffix changes, update any dependent projects (for example CHIRP PR #1414) so they whitelist the new `OEFW-LNR` banner.
 
 ## Branching and Release Flow

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -48,7 +48,7 @@ if [[ "${MODE}" == "cppcheck" ]]; then
 	exit 0
 fi
 
-: "${VERSION_SUFFIX:?VERSION_SUFFIX is required (set VERSION_SUFFIX=LNR24B1 before running this script)}"
+: "${VERSION_SUFFIX:?VERSION_SUFFIX is required (set VERSION_SUFFIX=LNR24.12.1 before running this script)}"
 
 mkdir -p "${ARTIFACT_DIR}"
 rm -f "${ARTIFACT_DIR}"/loaner-firmware*.bin

--- a/compile-with-docker.sh
+++ b/compile-with-docker.sh
@@ -6,7 +6,7 @@ OUT_DIR="${SCRIPT_DIR}/compiled-firmware"
 IMAGE_TAG="uvk5-loaner"
 
 if [[ -z "${VERSION_SUFFIX:-}" ]]; then
-  echo "VERSION_SUFFIX must be set (e.g. VERSION_SUFFIX=LNR24B1 ./compile-with-docker.sh)" >&2
+  echo "VERSION_SUFFIX must be set (e.g. VERSION_SUFFIX=LNR24.12.1 ./compile-with-docker.sh)" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- derive VERSION_SUFFIX from the pushed tag (e.g.  → ) before running the release build
- stop marking releases as prerelease and keep docs/examples in sync with the new suffix convention
- update helper scripts to use  in guidance messages

## Testing
- not run (CI-only change)