### PR TITLE
Update CHIRP CI suffix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -75,7 +75,7 @@ jobs:
     env:
       CHIRP_REPO: https://github.com/aditaa/chirp.git
       CHIRP_REF: loaner-firmware-whitelist
-      COMPAT_SUFFIX: LNR24.12.1
+      COMPAT_SUFFIX: LNR2414
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Switch the chirp-compat job to the new release banner (LNR2414) so workflows test against the version we just tagged.