### PR TITLE
Unlock transmit across supported bands

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -65,6 +65,9 @@ python3 fw-pack.py loaner-firmware.bin LNR2415 loaner-firmware.packed.bin
 ## Feature Toggles
 Feature flags live near the top of `Makefile` as `ENABLE_*` macros. The loaner build keeps the optional blocks (`AIRCOPY`, `ALARM`, `FMRADIO`, `NOAA`, `TX1750`, and the SRAM overlay) disabled by default to shrink the binary and hide extra menus. Adjust the macros if you need those features, then run `make clean` before comparing binary size after any toggle changes.
 
+## Transmit Policy
+The loaner build does not enforce the legacy regional `F LOCK` presets or the `200TX`, `350TX`, `350EN`, and `500TX` EEPROM switches. Those fields remain in the EEPROM layout for CHIRP compatibility, but runtime transmit validation only checks that a programmed transmit frequency falls inside one of the firmware's defined tuning bands: 50–76 MHz or 108–600 MHz. The unsupported 76–108 MHz gap, out-of-range frequencies, and non-transmittable special channel types remain blocked.
+
 ## Firmware Metadata and Releases
 - A successful build leaves you with `firmware.bin` (raw) and, when Python and `crcmod` are available, `firmware.packed.bin`. The packed image is what Quansheng's loader validates.
 - Use `fw-pack.py` to stamp a release tag into the packed image. `make` already invokes the script with `VERSION_SUFFIX`, so the packed file inherits the same banner. To repack manually, pass the suffix yourself (example above).

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The project also gives COML/COMT staff a predictable path from the ICS-205 form 
 - Friendly prompts: welcome banner, battery indicator, and RSSI display identify the handset as a loaner and keep checks simple.
 - Consistent keypad: digits recall the first ten memories, side buttons select the active VFO, and Menu is locked out.
 - Lean feature set: Aircopy, FM broadcast, NOAA weather, the 1750 Hz tone burst, and the general alarm are compiled out so the UI stays focused on assigned channels and the binary remains compact.
+- Unlocked transmit policy: regional lock presets do not restrict programmed memories. The firmware permits transmit throughout its defined 50–76 MHz and 108–600 MHz tuning bands; the person programming and operating each radio is responsible for choosing authorized frequencies, modes, power levels, and equipment.
 
 ## Programming Channel Plans With CHIRP
 This build assumes the channel plan lives on your ICS-205. To move that plan into a radio:

--- a/board.c
+++ b/board.c
@@ -673,16 +673,18 @@ void BOARD_EEPROM_Init(void)
 
 	// 0F40..0F47
 	EEPROM_ReadBuffer(0x0F40, Data, 8);
-	gSetting_F_LOCK         = (Data[0] < 6) ? Data[0] : F_LOCK_OFF;
+	// Regional transmit locks are retained in the EEPROM layout for CHIRP
+	// compatibility, but the loaner firmware always starts fully unlocked.
+	gSetting_F_LOCK         = F_LOCK_OFF;
 
 	gUpperLimitFrequencyBandTable = UpperLimitFrequencyBandTable;
 	gLowerLimitFrequencyBandTable = LowerLimitFrequencyBandTable;
 
-	gSetting_350TX          = (Data[1] < 2) ? Data[1] : true;
+	gSetting_350TX          = true;
 	gSetting_KILLED         = (Data[2] < 2) ? Data[2] : false;
-	gSetting_200TX          = (Data[3] < 2) ? Data[3] : false;
-	gSetting_500TX          = (Data[4] < 2) ? Data[4] : false;
-	gSetting_350EN          = (Data[5] < 2) ? Data[5] : true;
+	gSetting_200TX          = true;
+	gSetting_500TX          = true;
+	gSetting_350EN          = true;
 	gSetting_ScrambleEnable = (Data[6] < 2) ? Data[6] : true;
 
 	if (IS_FREQ_CHANNEL(gEeprom.ScreenChannel[0])) {

--- a/board.c
+++ b/board.c
@@ -680,11 +680,11 @@ void BOARD_EEPROM_Init(void)
 	gUpperLimitFrequencyBandTable = UpperLimitFrequencyBandTable;
 	gLowerLimitFrequencyBandTable = LowerLimitFrequencyBandTable;
 
-	gSetting_350TX = true;
-	gSetting_KILLED = (Data[2] < 2) ? Data[2] : false;
-	gSetting_200TX = true;
-	gSetting_500TX = true;
-	gSetting_350EN = true;
+	gSetting_350TX		= true;
+	gSetting_KILLED		= (Data[2] < 2) ? Data[2] : false;
+	gSetting_200TX		= true;
+	gSetting_500TX		= true;
+	gSetting_350EN		= true;
 	gSetting_ScrambleEnable = (Data[6] < 2) ? Data[6] : true;
 
 	if (IS_FREQ_CHANNEL(gEeprom.ScreenChannel[0])) {

--- a/board.c
+++ b/board.c
@@ -675,16 +675,16 @@ void BOARD_EEPROM_Init(void)
 	EEPROM_ReadBuffer(0x0F40, Data, 8);
 	// Regional transmit locks are retained in the EEPROM layout for CHIRP
 	// compatibility, but the loaner firmware always starts fully unlocked.
-	gSetting_F_LOCK         = F_LOCK_OFF;
+	gSetting_F_LOCK = F_LOCK_OFF;
 
 	gUpperLimitFrequencyBandTable = UpperLimitFrequencyBandTable;
 	gLowerLimitFrequencyBandTable = LowerLimitFrequencyBandTable;
 
-	gSetting_350TX          = true;
-	gSetting_KILLED         = (Data[2] < 2) ? Data[2] : false;
-	gSetting_200TX          = true;
-	gSetting_500TX          = true;
-	gSetting_350EN          = true;
+	gSetting_350TX = true;
+	gSetting_KILLED = (Data[2] < 2) ? Data[2] : false;
+	gSetting_200TX = true;
+	gSetting_500TX = true;
+	gSetting_350EN = true;
 	gSetting_ScrambleEnable = (Data[6] < 2) ? Data[6] : true;
 
 	if (IS_FREQ_CHANNEL(gEeprom.ScreenChannel[0])) {

--- a/frequencies.c
+++ b/frequencies.c
@@ -18,33 +18,33 @@
 #include "misc.h"
 
 const uint32_t LowerLimitFrequencyBandTable[BAND_COUNT] = {
-    5000000,
-    10800000,
-    13600000,
-    17400000,
-    35000000,
-    40000000,
-    47000000,
+	5000000,
+	10800000,
+	13600000,
+	17400000,
+	35000000,
+	40000000,
+	47000000,
 };
 
 const uint32_t MiddleFrequencyBandTable[BAND_COUNT] = {
-    6500000,
-    12200000,
-    15000000,
-    26000000,
-    37000000,
-    43500000,
-    55000000,
+	6500000,
+	12200000,
+	15000000,
+	26000000,
+	37000000,
+	43500000,
+	55000000,
 };
 
 const uint32_t UpperLimitFrequencyBandTable[BAND_COUNT] = {
-    7600000,
-    13599990,
-    17399990,
-    34999990,
-    39999990,
-    46999990,
-    60000000,
+	7600000,
+	13599990,
+	17399990,
+	34999990,
+	39999990,
+	46999990,
+	60000000,
 };
 
 #if defined(ENABLE_NOAA)
@@ -137,7 +137,7 @@ uint32_t FREQUENCY_FloorToStep(uint32_t Upper, uint32_t Step, uint32_t Lower)
 	return Lower + (Step * Index);
 }
 
-int FREQUENCY_Check(VFO_Info_t* pInfo)
+int FREQUENCY_Check(VFO_Info_t *pInfo)
 {
 	if (pInfo->CHANNEL_SAVE > FREQ_CHANNEL_LAST) {
 		return -1;

--- a/frequencies.c
+++ b/frequencies.c
@@ -18,33 +18,33 @@
 #include "misc.h"
 
 const uint32_t LowerLimitFrequencyBandTable[BAND_COUNT] = {
-	 5000000,
-	10800000,
-	13600000,
-	17400000,
-	35000000,
-	40000000,
-	47000000,
+    5000000,
+    10800000,
+    13600000,
+    17400000,
+    35000000,
+    40000000,
+    47000000,
 };
 
 const uint32_t MiddleFrequencyBandTable[BAND_COUNT] = {
-	 6500000,
-	12200000,
-	15000000,
-	26000000,
-	37000000,
-	43500000,
-	55000000,
+    6500000,
+    12200000,
+    15000000,
+    26000000,
+    37000000,
+    43500000,
+    55000000,
 };
 
 const uint32_t UpperLimitFrequencyBandTable[BAND_COUNT] = {
-	 7600000,
-	13599990,
-	17399990,
-	34999990,
-	39999990,
-	46999990,
-	60000000,
+    7600000,
+    13599990,
+    17399990,
+    34999990,
+    39999990,
+    46999990,
+    60000000,
 };
 
 #if defined(ENABLE_NOAA)
@@ -137,7 +137,7 @@ uint32_t FREQUENCY_FloorToStep(uint32_t Upper, uint32_t Step, uint32_t Lower)
 	return Lower + (Step * Index);
 }
 
-int FREQUENCY_Check(VFO_Info_t *pInfo)
+int FREQUENCY_Check(VFO_Info_t* pInfo)
 {
 	if (pInfo->CHANNEL_SAVE > FREQ_CHANNEL_LAST) {
 		return -1;

--- a/frequencies.c
+++ b/frequencies.c
@@ -16,9 +16,8 @@
 
 #include "frequencies.h"
 #include "misc.h"
-#include "settings.h"
 
-const uint32_t LowerLimitFrequencyBandTable[7] = {
+const uint32_t LowerLimitFrequencyBandTable[BAND_COUNT] = {
 	 5000000,
 	10800000,
 	13600000,
@@ -28,7 +27,7 @@ const uint32_t LowerLimitFrequencyBandTable[7] = {
 	47000000,
 };
 
-const uint32_t MiddleFrequencyBandTable[7] = {
+const uint32_t MiddleFrequencyBandTable[BAND_COUNT] = {
 	 6500000,
 	12200000,
 	15000000,
@@ -38,7 +37,7 @@ const uint32_t MiddleFrequencyBandTable[7] = {
 	55000000,
 };
 
-const uint32_t UpperLimitFrequencyBandTable[7] = {
+const uint32_t UpperLimitFrequencyBandTable[BAND_COUNT] = {
 	 7600000,
 	13599990,
 	17399990,
@@ -100,6 +99,19 @@ FREQUENCY_Band_t FREQUENCY_GetBand(uint32_t Frequency)
 	return BAND6_400MHz;
 }
 
+bool FREQUENCY_IsSupported(uint32_t Frequency)
+{
+	uint8_t Band;
+
+	for (Band = 0; Band < BAND_COUNT; Band++) {
+		if (Frequency >= LowerLimitFrequencyBandTable[Band] && Frequency <= UpperLimitFrequencyBandTable[Band]) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 uint8_t FREQUENCY_CalculateOutputPower(uint8_t TxpLow, uint8_t TxpMid, uint8_t TxpHigh, int32_t LowerLimit, int32_t Middle, int32_t UpperLimit, int32_t Frequency)
 {
 	if (Frequency <= LowerLimit) {
@@ -127,81 +139,9 @@ uint32_t FREQUENCY_FloorToStep(uint32_t Upper, uint32_t Step, uint32_t Lower)
 
 int FREQUENCY_Check(VFO_Info_t *pInfo)
 {
-	uint32_t Frequency;
-
 	if (pInfo->CHANNEL_SAVE > FREQ_CHANNEL_LAST) {
 		return -1;
 	}
-	Frequency = pInfo->pTX->Frequency;
-	switch (gSetting_F_LOCK) {
-	case F_LOCK_FCC:
-		if (Frequency >= 14400000 && Frequency <= 14799990) {
-			return 0;
-		}
-		if (Frequency >= 42000000 && Frequency <= 44999990) {
-			return 0;
-		}
-		break;
 
-	case F_LOCK_CE:
-		if (Frequency >= 14400000 && Frequency <= 14599990) {
-			return 0;
-		}
-		break;
-
-	case F_LOCK_GB:
-		if (Frequency >= 14400000 && Frequency <= 14799990) {
-			return 0;
-		}
-		if (Frequency >= 43000000 && Frequency <= 43999990) {
-			return 0;
-		}
-		break;
-
-	case F_LOCK_430:
-		if (Frequency >= 13600000 && Frequency <= 17399990) {
-			return 0;
-		}
-		if (Frequency >= 40000000 && Frequency <= 42999990) {
-			return 0;
-		}
-		break;
-
-	case F_LOCK_438:
-		if (Frequency >= 13600000 && Frequency <= 17399990) {
-			return 0;
-		}
-		if (Frequency >= 40000000 && Frequency <= 43799990) {
-			return 0;
-		}
-		break;
-
-	default:
-		if (Frequency >= 13600000 && Frequency <= 17399990) {
-			return 0;
-		}
-		if (Frequency >= 35000000 && Frequency <= 39999990) {
-			if (gSetting_350TX && gSetting_350EN) {
-				return 0;
-			}
-		}
-		if (Frequency >= 40000000 && Frequency <= 46999990) {
-			return 0;
-		}
-		if (Frequency >= 17400000 && Frequency <= 34999990) {
-			if (gSetting_200TX) {
-				return 0;
-			}
-		}
-
-		if (Frequency >= 47000000 && Frequency <= 60000000) {
-			if (gSetting_500TX) {
-				return 0;
-			}
-		}
-		break;
-	}
-
-	return -1;
+	return FREQUENCY_IsSupported(pInfo->pTX->Frequency) ? 0 : -1;
 }
-

--- a/frequencies.h
+++ b/frequencies.h
@@ -21,8 +21,7 @@
 #include <stdint.h>
 #include "radio.h"
 
-enum FREQUENCY_Band_t
-{
+enum FREQUENCY_Band_t {
 	BAND1_50MHz = 0,
 	BAND2_108MHz,
 	BAND3_136MHz,
@@ -47,6 +46,6 @@ FREQUENCY_Band_t FREQUENCY_GetBand(uint32_t Frequency);
 bool FREQUENCY_IsSupported(uint32_t Frequency);
 uint8_t FREQUENCY_CalculateOutputPower(uint8_t TxpLow, uint8_t TxpMid, uint8_t TxpHigh, int32_t LowerLimit, int32_t Middle, int32_t UpperLimit, int32_t Frequency);
 uint32_t FREQUENCY_FloorToStep(uint32_t Upper, uint32_t Step, uint32_t Lower);
-int FREQUENCY_Check(VFO_Info_t* pInfo);
+int FREQUENCY_Check(VFO_Info_t *pInfo);
 
 #endif

--- a/frequencies.h
+++ b/frequencies.h
@@ -21,7 +21,8 @@
 #include <stdint.h>
 #include "radio.h"
 
-enum FREQUENCY_Band_t {
+enum FREQUENCY_Band_t
+{
 	BAND1_50MHz = 0,
 	BAND2_108MHz,
 	BAND3_136MHz,
@@ -46,6 +47,6 @@ FREQUENCY_Band_t FREQUENCY_GetBand(uint32_t Frequency);
 bool FREQUENCY_IsSupported(uint32_t Frequency);
 uint8_t FREQUENCY_CalculateOutputPower(uint8_t TxpLow, uint8_t TxpMid, uint8_t TxpHigh, int32_t LowerLimit, int32_t Middle, int32_t UpperLimit, int32_t Frequency);
 uint32_t FREQUENCY_FloorToStep(uint32_t Upper, uint32_t Step, uint32_t Lower);
-int FREQUENCY_Check(VFO_Info_t *pInfo);
+int FREQUENCY_Check(VFO_Info_t* pInfo);
 
 #endif

--- a/frequencies.h
+++ b/frequencies.h
@@ -17,6 +17,7 @@
 #ifndef FREQUENCIES_H
 #define FREQUENCIES_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include "radio.h"
 
@@ -28,22 +29,23 @@ enum FREQUENCY_Band_t {
 	BAND5_350MHz,
 	BAND6_400MHz,
 	BAND7_470MHz,
+	BAND_COUNT,
 };
 
 typedef enum FREQUENCY_Band_t FREQUENCY_Band_t;
 
-extern const uint32_t LowerLimitFrequencyBandTable[7];
-extern const uint32_t MiddleFrequencyBandTable[7];
-extern const uint32_t UpperLimitFrequencyBandTable[7];
+extern const uint32_t LowerLimitFrequencyBandTable[BAND_COUNT];
+extern const uint32_t MiddleFrequencyBandTable[BAND_COUNT];
+extern const uint32_t UpperLimitFrequencyBandTable[BAND_COUNT];
 #if defined(ENABLE_NOAA)
 extern const uint32_t NoaaFrequencyTable[10];
 #endif
 extern const uint16_t StepFrequencyTable[7];
 
 FREQUENCY_Band_t FREQUENCY_GetBand(uint32_t Frequency);
+bool FREQUENCY_IsSupported(uint32_t Frequency);
 uint8_t FREQUENCY_CalculateOutputPower(uint8_t TxpLow, uint8_t TxpMid, uint8_t TxpHigh, int32_t LowerLimit, int32_t Middle, int32_t UpperLimit, int32_t Frequency);
 uint32_t FREQUENCY_FloorToStep(uint32_t Upper, uint32_t Step, uint32_t Lower);
 int FREQUENCY_Check(VFO_Info_t *pInfo);
 
 #endif
-

--- a/radio.c
+++ b/radio.c
@@ -143,15 +143,6 @@ void RADIO_ConfigureChannel(uint8_t VFO, uint32_t Configure)
 
 	pRadio = &gEeprom.VfoInfo[VFO];
 
-	if (!gSetting_350EN) {
-		if (gEeprom.FreqChannel[VFO] == FREQ_CHANNEL_FIRST + BAND5_350MHz) {
-			gEeprom.FreqChannel[VFO] = FREQ_CHANNEL_FIRST + BAND6_400MHz;
-		}
-		if (gEeprom.ScreenChannel[VFO] == FREQ_CHANNEL_FIRST + BAND5_350MHz) {
-			gEeprom.ScreenChannel[VFO] = FREQ_CHANNEL_FIRST + BAND6_400MHz;
-		}
-	}
-
 	Channel = gEeprom.ScreenChannel[VFO];
 	if (IS_VALID_CHANNEL(Channel)) {
 #if defined(ENABLE_NOAA)
@@ -368,13 +359,6 @@ void RADIO_ConfigureChannel(uint8_t VFO, uint32_t Configure)
 	} else {
 		gEeprom.VfoInfo[VFO].pRX = &gEeprom.VfoInfo[VFO].ConfigTX;
 		gEeprom.VfoInfo[VFO].pTX = &gEeprom.VfoInfo[VFO].ConfigRX;
-	}
-
-	if (!gSetting_350EN) {
-		FREQ_Config_t *pConfig = gEeprom.VfoInfo[VFO].pRX;
-		if (pConfig->Frequency >= 35000000 && pConfig->Frequency <= 39999990) {
-			pConfig->Frequency = 41001250;
-		}
 	}
 
 	if (gEeprom.VfoInfo[VFO].Band == BAND2_108MHz && gEeprom.VfoInfo[VFO].AM_CHANNEL_MODE) {

--- a/tests/test_frequency_policy.py
+++ b/tests/test_frequency_policy.py
@@ -1,0 +1,126 @@
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def frequency_policy_binary(tmp_path_factory):
+    compiler = shutil.which("cc") or shutil.which("gcc")
+    if compiler is None:
+        pytest.skip("A host C compiler is required for the frequency policy test")
+
+    build_dir = tmp_path_factory.mktemp("frequency-policy")
+    harness = build_dir / "frequency_policy_harness.c"
+    executable = build_dir / "frequency_policy_harness"
+    harness.write_text(
+        textwrap.dedent(
+            """
+            #include <stdint.h>
+            #include <stdio.h>
+            #include <stdlib.h>
+
+            #include "frequencies.h"
+            #include "misc.h"
+
+            int main(int argc, char **argv)
+            {
+                FREQ_Config_t tx;
+                VFO_Info_t vfo = {0};
+                uint32_t frequency;
+                uint8_t channel;
+
+                if (argc != 3) {
+                    return 2;
+                }
+
+                frequency = (uint32_t)strtoul(argv[1], NULL, 10);
+                channel = (uint8_t)strtoul(argv[2], NULL, 10);
+                tx.Frequency = frequency;
+                vfo.pTX = &tx;
+                vfo.CHANNEL_SAVE = channel;
+
+                printf("%u %d\\n",
+                       FREQUENCY_IsSupported(frequency),
+                       FREQUENCY_Check(&vfo));
+                return 0;
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+    subprocess.run(
+        [
+            compiler,
+            "-std=c11",
+            "-Wall",
+            "-Werror",
+            "-I",
+            str(ROOT),
+            str(ROOT / "frequencies.c"),
+            str(harness),
+            "-o",
+            str(executable),
+        ],
+        check=True,
+    )
+    return executable
+
+
+def run_policy(executable, frequency, channel=0):
+    result = subprocess.run(
+        [str(executable), str(frequency), str(channel)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    supported, check_result = result.stdout.split()
+    return supported == "1", int(check_result)
+
+
+@pytest.mark.parametrize(
+    ("frequency", "expected"),
+    [
+        (4_999_999, False),
+        (5_000_000, True),
+        (7_600_000, True),
+        (7_600_001, False),
+        (10_799_999, False),
+        (10_800_000, True),
+        (13_599_990, True),
+        (13_600_000, True),
+        (17_399_990, True),
+        (17_400_000, True),
+        (34_999_990, True),
+        (35_000_000, True),
+        (39_999_990, True),
+        (40_000_000, True),
+        (46_255_000, True),
+        (46_755_000, True),
+        (46_999_990, True),
+        (47_000_000, True),
+        (60_000_000, True),
+        (60_000_001, False),
+    ],
+)
+def test_supported_transmit_ranges(frequency_policy_binary, frequency, expected):
+    supported, check_result = run_policy(frequency_policy_binary, frequency)
+
+    assert supported is expected
+    assert check_result == (0 if expected else -1)
+
+
+def test_special_channels_remain_non_transmittable(frequency_policy_binary):
+    supported, check_result = run_policy(
+        frequency_policy_binary,
+        46_255_000,
+        channel=207,
+    )
+
+    assert supported is True
+    assert check_result == -1


### PR DESCRIPTION
## Summary

- remove the legacy regional transmit-lock presets and the 200TX, 350TX, 350EN, and 500TX runtime gates
- permit transmit across the firmware's defined 50–76 MHz and 108–600 MHz tuning bands
- retain the legacy EEPROM fields for CHIRP compatibility and initialize them to their open values
- continue blocking the unsupported 76–108 MHz gap, out-of-range frequencies, and non-transmittable special channels
- document the unlocked transmit policy and add host-compiled regression tests for band boundaries and representative GMRS frequencies

## Why

Issue #34 is caused by the regional frequency-lock policy rejecting programmed transmit frequencies even when they are within the radio firmware's supported tuning bands. This makes the firmware itself the limiting policy layer for authorized interoperability, modified-amateur, and non-US use cases.

The operator and programming workflow now determine which frequencies are appropriate, while the firmware retains only its hardware-range and channel-type safeguards.

## Impact

Programmed memories, including GMRS channel 15 at 462.550 MHz, can transmit when they fall within a defined tuning band. Existing CHIRP layouts remain compatible.

## Validation

- Docker cppcheck passed
- pytest passed: 23 tests
- ARM firmware build passed
- raw firmware size: 50,564 bytes
- CHIRP firmware identifier and driver compatibility checks passed
- hardware radio validation remains recommended before release

Closes #34