### PR TITLE
Harden UART command parsing and EEPROM bounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.o
 *.d
+__pycache__/
 /compiled-firmware
 link-overlay.S
 sram-overlay
 sram-overlay.bin
-

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ OBJS += app/menu.o
 OBJS += app/scanner.o
 ifeq ($(ENABLE_UART),1)
 OBJS += app/uart.o
+OBJS += app/uart_protocol.o
 endif
 OBJS += audio.o
 OBJS += bitmaps.o

--- a/app/uart.c
+++ b/app/uart.c
@@ -22,6 +22,7 @@
 #include "app/fm.h"
 #endif
 #include "app/uart.h"
+#include "app/uart_protocol.h"
 #include "board.h"
 #include "bsp/dp32g030/dma.h"
 #include "bsp/dp32g030/gpio.h"
@@ -39,26 +40,29 @@
 #endif
 #include "version.h"
 
-#define DMA_INDEX(x, y) (((x) + (y)) % sizeof(UART_DMA_Buffer))
-
-typedef struct {
+typedef struct
+{
 	uint16_t ID;
 	uint16_t Size;
 } Header_t;
 
-typedef struct {
+typedef struct
+{
 	uint8_t Padding[2];
 	uint16_t ID;
 } Footer_t;
 
-typedef struct {
+typedef struct
+{
 	Header_t Header;
 	uint32_t Timestamp;
 } CMD_0514_t;
 
-typedef struct {
+typedef struct
+{
 	Header_t Header;
-	struct {
+	struct
+	{
 		char Version[16];
 		bool bHasCustomAesKey;
 		bool bIsInLockScreen;
@@ -67,7 +71,8 @@ typedef struct {
 	} Data;
 } REPLY_0514_t;
 
-typedef struct {
+typedef struct
+{
 	Header_t Header;
 	uint16_t Offset;
 	uint8_t Size;
@@ -75,9 +80,11 @@ typedef struct {
 	uint32_t Timestamp;
 } CMD_051B_t;
 
-typedef struct {
+typedef struct
+{
 	Header_t Header;
-	struct {
+	struct
+	{
 		uint16_t Offset;
 		uint8_t Size;
 		uint8_t Padding;
@@ -85,7 +92,8 @@ typedef struct {
 	} Data;
 } REPLY_051B_t;
 
-typedef struct {
+typedef struct
+{
 	Header_t Header;
 	uint16_t Offset;
 	uint8_t Size;
@@ -94,53 +102,64 @@ typedef struct {
 	uint8_t Data[0];
 } CMD_051D_t;
 
-typedef struct {
+typedef struct
+{
 	Header_t Header;
-	struct {
+	struct
+	{
 		uint16_t Offset;
 	} Data;
 } REPLY_051D_t;
 
-typedef struct {
+typedef struct
+{
 	Header_t Header;
-	struct {
+	struct
+	{
 		uint16_t RSSI;
 		uint8_t ExNoiseIndicator;
 		uint8_t GlitchIndicator;
 	} Data;
 } REPLY_0527_t;
 
-typedef struct {
+typedef struct
+{
 	Header_t Header;
-	struct {
+	struct
+	{
 		uint16_t Voltage;
 		uint16_t Current;
 	} Data;
 } REPLY_0529_t;
 
-typedef struct {
+typedef struct
+{
 	Header_t Header;
 	uint32_t Response[4];
 } CMD_052D_t;
 
-typedef struct {
+typedef struct
+{
 	Header_t Header;
-	struct {
+	struct
+	{
 		bool bIsLocked;
 		uint8_t Padding[3];
 	} Data;
 } REPLY_052D_t;
 
-typedef struct {
+typedef struct
+{
 	Header_t Header;
 	uint32_t Timestamp;
 } CMD_052F_t;
 
-static const uint8_t Obfuscation[16] = { 0x16, 0x6C, 0x14, 0xE6, 0x2E, 0x91, 0x0D, 0x40, 0x21, 0x35, 0xD5, 0x40, 0x13, 0x03, 0xE9, 0x80 };
+static const uint8_t Obfuscation[16] = {0x16, 0x6C, 0x14, 0xE6, 0x2E, 0x91, 0x0D, 0x40, 0x21, 0x35, 0xD5, 0x40, 0x13, 0x03, 0xE9, 0x80};
 
 static union {
 	uint8_t Buffer[256];
-	struct {
+	struct
+	{
 		Header_t Header;
 		uint8_t Data[252];
 	};
@@ -148,17 +167,18 @@ static union {
 
 static uint32_t Timestamp;
 static uint16_t gUART_WriteIndex;
+static uint16_t UART_CommandSize;
 static bool bIsEncrypted = true;
 
-static void SendReply(void *pReply, uint16_t Size)
+static void SendReply(void* pReply, uint16_t Size)
 {
 	Header_t Header;
 	Footer_t Footer;
-	uint8_t *pBytes;
+	uint8_t* pBytes;
 	uint16_t i;
 
 	if (bIsEncrypted) {
-		pBytes = (uint8_t *)pReply;
+		pBytes = (uint8_t*)pReply;
 		for (i = 0; i < Size; i++) {
 			pBytes[i] ^= Obfuscation[i % 16];
 		}
@@ -182,7 +202,7 @@ static void SendReply(void *pReply, uint16_t Size)
 
 static void SendVersion(void)
 {
-	REPLY_0514_t Reply;
+	REPLY_0514_t Reply = {0};
 
 	Reply.Header.ID = 0x0515;
 	Reply.Header.Size = sizeof(Reply.Data);
@@ -197,7 +217,7 @@ static void SendVersion(void)
 	SendReply(&Reply, sizeof(Reply));
 }
 
-static bool IsBadChallenge(const uint32_t *pKey, const uint32_t *pIn, const uint32_t *pResponse)
+static bool IsBadChallenge(const uint32_t* pKey, const uint32_t* pIn, const uint32_t* pResponse)
 {
 	uint8_t i;
 	uint32_t IV[4];
@@ -216,9 +236,9 @@ static bool IsBadChallenge(const uint32_t *pKey, const uint32_t *pIn, const uint
 	return false;
 }
 
-static void CMD_0514(const uint8_t *pBuffer)
+static void CMD_0514(const uint8_t* pBuffer)
 {
-	const CMD_0514_t *pCmd = (const CMD_0514_t *)pBuffer;
+	const CMD_0514_t* pCmd = (const CMD_0514_t*)pBuffer;
 
 	Timestamp = pCmd->Timestamp;
 #if defined(ENABLE_FMRADIO)
@@ -228,10 +248,10 @@ static void CMD_0514(const uint8_t *pBuffer)
 	SendVersion();
 }
 
-static void CMD_051B(const uint8_t *pBuffer)
+static void CMD_051B(const uint8_t* pBuffer)
 {
-	const CMD_051B_t *pCmd = (const CMD_051B_t *)pBuffer;
-	REPLY_051B_t Reply;
+	const CMD_051B_t* pCmd = (const CMD_051B_t*)pBuffer;
+	REPLY_051B_t Reply = {0};
 	bool bLocked = false;
 
 	if (pCmd->Timestamp != Timestamp) {
@@ -241,7 +261,6 @@ static void CMD_051B(const uint8_t *pBuffer)
 #if defined(ENABLE_FMRADIO)
 	gFmRadioCountdown = 4;
 #endif
-	memset(&Reply, 0, sizeof(Reply));
 	Reply.Header.ID = 0x051C;
 	Reply.Header.Size = pCmd->Size + 4;
 	Reply.Data.Offset = pCmd->Offset;
@@ -258,10 +277,10 @@ static void CMD_051B(const uint8_t *pBuffer)
 	SendReply(&Reply, pCmd->Size + 8);
 }
 
-static void CMD_051D(const uint8_t *pBuffer)
+static void CMD_051D(const uint8_t* pBuffer)
 {
-	const CMD_051D_t *pCmd = (const CMD_051D_t *)pBuffer;
-	REPLY_051D_t Reply;
+	const CMD_051D_t* pCmd = (const CMD_051D_t*)pBuffer;
+	REPLY_051D_t Reply = {0};
 	bool bReloadEeprom;
 	bool bIsLocked;
 
@@ -310,7 +329,7 @@ static void CMD_051D(const uint8_t *pBuffer)
 
 static void CMD_0527(void)
 {
-	REPLY_0527_t Reply;
+	REPLY_0527_t Reply = {0};
 
 	Reply.Header.ID = 0x0528;
 	Reply.Header.Size = sizeof(Reply.Data);
@@ -323,7 +342,7 @@ static void CMD_0527(void)
 
 static void CMD_0529(void)
 {
-	REPLY_0529_t Reply;
+	REPLY_0529_t Reply = {0};
 
 	Reply.Header.ID = 0x52A;
 	Reply.Header.Size = sizeof(Reply.Data);
@@ -332,10 +351,10 @@ static void CMD_0529(void)
 	SendReply(&Reply, sizeof(Reply));
 }
 
-static void CMD_052D(const uint8_t *pBuffer)
+static void CMD_052D(const uint8_t* pBuffer)
 {
-	const CMD_052D_t *pCmd = (const CMD_052D_t *)pBuffer;
-	REPLY_052D_t Reply;
+	const CMD_052D_t* pCmd = (const CMD_052D_t*)pBuffer;
+	REPLY_052D_t Reply = {0};
 	bool bIsLocked;
 
 #if defined(ENABLE_FMRADIO)
@@ -368,9 +387,9 @@ static void CMD_052D(const uint8_t *pBuffer)
 	SendReply(&Reply, sizeof(Reply));
 }
 
-static void CMD_052F(const uint8_t *pBuffer)
+static void CMD_052F(const uint8_t* pBuffer)
 {
-	const CMD_052F_t *pCmd = (const CMD_052F_t *)pBuffer;
+	const CMD_052F_t* pCmd = (const CMD_052F_t*)pBuffer;
 
 	gEeprom.DUAL_WATCH = DUAL_WATCH_OFF;
 	gEeprom.CROSS_BAND_RX_TX = CROSS_BAND_OFF;
@@ -397,98 +416,47 @@ static void CMD_052F(const uint8_t *pBuffer)
 bool UART_IsCommandAvailable(void)
 {
 	uint16_t DmaLength;
-	uint16_t CommandLength;
-	uint16_t Index;
-	uint16_t TailIndex;
-	uint16_t Size;
-	uint16_t CRC;
-	uint16_t i;
+	uint16_t NextWriteIndex;
+	bool bNextIsEncrypted;
+	UART_PROTOCOL_FrameResult_t Result;
 
 	DmaLength = DMA_CH0->ST & 0xFFFU;
-	while (1) {
-		if (gUART_WriteIndex == DmaLength) {
-			return false;
-		}
+	UART_CommandSize = 0;
+	Result = UART_PROTOCOL_ParseFrame(
+	    UART_DMA_Buffer,
+	    sizeof(UART_DMA_Buffer),
+	    gUART_WriteIndex,
+	    DmaLength,
+	    bIsEncrypted,
+	    UART_Command.Buffer,
+	    sizeof(UART_Command.Buffer),
+	    &NextWriteIndex,
+	    &UART_CommandSize,
+	    &bNextIsEncrypted);
 
-		while (gUART_WriteIndex != DmaLength && UART_DMA_Buffer[gUART_WriteIndex] != 0xABU) {
-			gUART_WriteIndex = DMA_INDEX(gUART_WriteIndex, 1);
-		}
-
-		if (gUART_WriteIndex == DmaLength) {
-			return false;
-		}
-
-		if (gUART_WriteIndex < DmaLength) {
-			CommandLength = DmaLength - gUART_WriteIndex;
-		} else {
-			CommandLength = (DmaLength + sizeof(UART_DMA_Buffer)) - gUART_WriteIndex;
-		}
-		if (CommandLength < 8) {
-			return 0;
-		}
-		if (UART_DMA_Buffer[DMA_INDEX(gUART_WriteIndex, 1)] == 0xCD) {
-			break;
-		}
-		gUART_WriteIndex = DMA_INDEX(gUART_WriteIndex, 1);
-	}
-
-	Index = DMA_INDEX(gUART_WriteIndex, 2);
-	Size = (UART_DMA_Buffer[DMA_INDEX(Index, 1)] << 8) | UART_DMA_Buffer[Index];
-	if (Size + 8 > sizeof(UART_DMA_Buffer)) {
-		gUART_WriteIndex = DmaLength;
-		return false;
-	}
-	if (CommandLength < Size + 8) {
-		return false;
-	}
-	Index = DMA_INDEX(Index, 2);
-	TailIndex = DMA_INDEX(Index, Size + 2);
-	if (UART_DMA_Buffer[TailIndex] != 0xDC || UART_DMA_Buffer[DMA_INDEX(TailIndex, 1)] != 0xBA) {
-		gUART_WriteIndex = DmaLength;
-		return false;
-	}
-	if (TailIndex < Index) {
-		uint16_t ChunkSize = sizeof(UART_DMA_Buffer) - Index;
-
-		memcpy(UART_Command.Buffer, UART_DMA_Buffer + Index, ChunkSize);
-		memcpy(UART_Command.Buffer + ChunkSize, UART_DMA_Buffer, TailIndex);
-	} else {
-		memcpy(UART_Command.Buffer, UART_DMA_Buffer + Index, TailIndex - Index);
-	}
-
-	TailIndex = DMA_INDEX(TailIndex, 2);
-	if (TailIndex < gUART_WriteIndex) {
+	if (NextWriteIndex < gUART_WriteIndex) {
 		memset(UART_DMA_Buffer + gUART_WriteIndex, 0, sizeof(UART_DMA_Buffer) - gUART_WriteIndex);
-		memset(UART_DMA_Buffer, 0, TailIndex);
-	} else {
-		memset(UART_DMA_Buffer + gUART_WriteIndex, 0, TailIndex - gUART_WriteIndex);
+		memset(UART_DMA_Buffer, 0, NextWriteIndex);
+	} else if (NextWriteIndex > gUART_WriteIndex) {
+		memset(UART_DMA_Buffer + gUART_WriteIndex, 0, NextWriteIndex - gUART_WriteIndex);
 	}
+	gUART_WriteIndex = NextWriteIndex;
 
-	gUART_WriteIndex = TailIndex;
-
-	if (UART_Command.Header.ID == 0x0514) {
-		bIsEncrypted = false;
-	}
-	if (UART_Command.Header.ID == 0x6902) {
-		bIsEncrypted = true;
-	}
-
-	if (bIsEncrypted) {
-		for (i = 0; i < Size + 2; i++) {
-			UART_Command.Buffer[i] ^= Obfuscation[i % 16];
-		}
-	}
-
-	CRC = UART_Command.Buffer[Size] | (UART_Command.Buffer[Size + 1] << 8);
-	if (CRC_Calculate(UART_Command.Buffer, Size) != CRC) {
+	if (Result != UART_PROTOCOL_FRAME_COMMAND) {
 		return false;
 	}
 
+	bIsEncrypted = bNextIsEncrypted;
 	return true;
 }
 
 void UART_HandleCommand(void)
 {
+	if (!UART_PROTOCOL_ValidateCommand(UART_Command.Buffer, UART_CommandSize)) {
+		return;
+	}
+	UART_CommandSize = 0;
+
 	switch (UART_Command.Header.ID) {
 	case 0x0514:
 		CMD_0514(UART_Command.Buffer);

--- a/app/uart.c
+++ b/app/uart.c
@@ -154,7 +154,7 @@ typedef struct
 	uint32_t Timestamp;
 } CMD_052F_t;
 
-static const uint8_t Obfuscation[16] = {0x16, 0x6C, 0x14, 0xE6, 0x2E, 0x91, 0x0D, 0x40, 0x21, 0x35, 0xD5, 0x40, 0x13, 0x03, 0xE9, 0x80};
+static const uint8_t Obfuscation[16] = { 0x16, 0x6C, 0x14, 0xE6, 0x2E, 0x91, 0x0D, 0x40, 0x21, 0x35, 0xD5, 0x40, 0x13, 0x03, 0xE9, 0x80 };
 
 static union {
 	uint8_t Buffer[256];
@@ -170,15 +170,15 @@ static uint16_t gUART_WriteIndex;
 static uint16_t UART_CommandSize;
 static bool bIsEncrypted = true;
 
-static void SendReply(void* pReply, uint16_t Size)
+static void SendReply(void *pReply, uint16_t Size)
 {
 	Header_t Header;
 	Footer_t Footer;
-	uint8_t* pBytes;
+	uint8_t *pBytes;
 	uint16_t i;
 
 	if (bIsEncrypted) {
-		pBytes = (uint8_t*)pReply;
+		pBytes = (uint8_t *)pReply;
 		for (i = 0; i < Size; i++) {
 			pBytes[i] ^= Obfuscation[i % 16];
 		}
@@ -202,7 +202,7 @@ static void SendReply(void* pReply, uint16_t Size)
 
 static void SendVersion(void)
 {
-	REPLY_0514_t Reply = {0};
+	REPLY_0514_t Reply = { 0 };
 
 	Reply.Header.ID = 0x0515;
 	Reply.Header.Size = sizeof(Reply.Data);
@@ -217,7 +217,7 @@ static void SendVersion(void)
 	SendReply(&Reply, sizeof(Reply));
 }
 
-static bool IsBadChallenge(const uint32_t* pKey, const uint32_t* pIn, const uint32_t* pResponse)
+static bool IsBadChallenge(const uint32_t *pKey, const uint32_t *pIn, const uint32_t *pResponse)
 {
 	uint8_t i;
 	uint32_t IV[4];
@@ -236,9 +236,9 @@ static bool IsBadChallenge(const uint32_t* pKey, const uint32_t* pIn, const uint
 	return false;
 }
 
-static void CMD_0514(const uint8_t* pBuffer)
+static void CMD_0514(const uint8_t *pBuffer)
 {
-	const CMD_0514_t* pCmd = (const CMD_0514_t*)pBuffer;
+	const CMD_0514_t *pCmd = (const CMD_0514_t *)pBuffer;
 
 	Timestamp = pCmd->Timestamp;
 #if defined(ENABLE_FMRADIO)
@@ -248,10 +248,10 @@ static void CMD_0514(const uint8_t* pBuffer)
 	SendVersion();
 }
 
-static void CMD_051B(const uint8_t* pBuffer)
+static void CMD_051B(const uint8_t *pBuffer)
 {
-	const CMD_051B_t* pCmd = (const CMD_051B_t*)pBuffer;
-	REPLY_051B_t Reply = {0};
+	const CMD_051B_t *pCmd = (const CMD_051B_t *)pBuffer;
+	REPLY_051B_t Reply     = { 0 };
 	bool bLocked = false;
 
 	if (pCmd->Timestamp != Timestamp) {
@@ -277,10 +277,10 @@ static void CMD_051B(const uint8_t* pBuffer)
 	SendReply(&Reply, pCmd->Size + 8);
 }
 
-static void CMD_051D(const uint8_t* pBuffer)
+static void CMD_051D(const uint8_t *pBuffer)
 {
-	const CMD_051D_t* pCmd = (const CMD_051D_t*)pBuffer;
-	REPLY_051D_t Reply = {0};
+	const CMD_051D_t *pCmd = (const CMD_051D_t *)pBuffer;
+	REPLY_051D_t Reply     = { 0 };
 	bool bReloadEeprom;
 	bool bIsLocked;
 
@@ -329,7 +329,7 @@ static void CMD_051D(const uint8_t* pBuffer)
 
 static void CMD_0527(void)
 {
-	REPLY_0527_t Reply = {0};
+	REPLY_0527_t Reply = { 0 };
 
 	Reply.Header.ID = 0x0528;
 	Reply.Header.Size = sizeof(Reply.Data);
@@ -342,7 +342,7 @@ static void CMD_0527(void)
 
 static void CMD_0529(void)
 {
-	REPLY_0529_t Reply = {0};
+	REPLY_0529_t Reply = { 0 };
 
 	Reply.Header.ID = 0x52A;
 	Reply.Header.Size = sizeof(Reply.Data);
@@ -351,10 +351,10 @@ static void CMD_0529(void)
 	SendReply(&Reply, sizeof(Reply));
 }
 
-static void CMD_052D(const uint8_t* pBuffer)
+static void CMD_052D(const uint8_t *pBuffer)
 {
-	const CMD_052D_t* pCmd = (const CMD_052D_t*)pBuffer;
-	REPLY_052D_t Reply = {0};
+	const CMD_052D_t *pCmd = (const CMD_052D_t *)pBuffer;
+	REPLY_052D_t Reply     = { 0 };
 	bool bIsLocked;
 
 #if defined(ENABLE_FMRADIO)
@@ -387,9 +387,9 @@ static void CMD_052D(const uint8_t* pBuffer)
 	SendReply(&Reply, sizeof(Reply));
 }
 
-static void CMD_052F(const uint8_t* pBuffer)
+static void CMD_052F(const uint8_t *pBuffer)
 {
-	const CMD_052F_t* pCmd = (const CMD_052F_t*)pBuffer;
+	const CMD_052F_t *pCmd = (const CMD_052F_t *)pBuffer;
 
 	gEeprom.DUAL_WATCH = DUAL_WATCH_OFF;
 	gEeprom.CROSS_BAND_RX_TX = CROSS_BAND_OFF;
@@ -422,17 +422,17 @@ bool UART_IsCommandAvailable(void)
 
 	DmaLength = DMA_CH0->ST & 0xFFFU;
 	UART_CommandSize = 0;
-	Result = UART_PROTOCOL_ParseFrame(
-	    UART_DMA_Buffer,
-	    sizeof(UART_DMA_Buffer),
-	    gUART_WriteIndex,
-	    DmaLength,
-	    bIsEncrypted,
-	    UART_Command.Buffer,
-	    sizeof(UART_Command.Buffer),
-	    &NextWriteIndex,
-	    &UART_CommandSize,
-	    &bNextIsEncrypted);
+	Result		 = UART_PROTOCOL_ParseFrame(
+			  UART_DMA_Buffer,
+			  sizeof(UART_DMA_Buffer),
+			  gUART_WriteIndex,
+			  DmaLength,
+			  bIsEncrypted,
+			  UART_Command.Buffer,
+			  sizeof(UART_Command.Buffer),
+			  &NextWriteIndex,
+			  &UART_CommandSize,
+			  &bNextIsEncrypted);
 
 	if (NextWriteIndex < gUART_WriteIndex) {
 		memset(UART_DMA_Buffer + gUART_WriteIndex, 0, sizeof(UART_DMA_Buffer) - gUART_WriteIndex);

--- a/app/uart_protocol.c
+++ b/app/uart_protocol.c
@@ -1,0 +1,211 @@
+/* Copyright 2023 Dual Tachyon
+ * https://github.com/DualTachyon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "app/uart_protocol.h"
+#include "driver/crc.h"
+
+static const uint8_t Obfuscation[16] = {0x16, 0x6C, 0x14, 0xE6, 0x2E, 0x91, 0x0D, 0x40, 0x21, 0x35, 0xD5, 0x40, 0x13, 0x03, 0xE9, 0x80};
+
+static uint16_t AddRingIndex(uint16_t Index, uint16_t Amount, uint16_t RingBufferSize)
+{
+	return (Index + Amount) % RingBufferSize;
+}
+
+static uint16_t GetRingDistance(uint16_t Start, uint16_t End, uint16_t RingBufferSize)
+{
+	if (End >= Start) {
+		return End - Start;
+	}
+
+	return (RingBufferSize - Start) + End;
+}
+
+static uint16_t ReadUint16(const uint8_t* pData)
+{
+	return pData[0] | ((uint16_t)pData[1] << 8);
+}
+
+static uint16_t ReadRingUint16(const uint8_t* pRingBuffer, uint16_t RingBufferSize, uint16_t Index)
+{
+	return pRingBuffer[Index] | ((uint16_t)pRingBuffer[AddRingIndex(Index, 1, RingBufferSize)] << 8);
+}
+
+static bool IsEepromRangeValid(uint16_t Offset, uint16_t Size)
+{
+	return Size > 0 && (uint32_t)Offset + Size <= UART_PROTOCOL_EEPROM_SIZE;
+}
+
+bool UART_PROTOCOL_ValidateCommand(const uint8_t* pCommand, uint16_t CommandSize)
+{
+	uint16_t ID;
+	uint16_t HeaderSize;
+
+	if (CommandSize < 4) {
+		return false;
+	}
+
+	ID = ReadUint16(&pCommand[0]);
+	HeaderSize = ReadUint16(&pCommand[2]);
+	if (HeaderSize != CommandSize - 4U) {
+		return false;
+	}
+
+	switch (ID) {
+	case 0x0514:
+	case 0x052F:
+		return CommandSize == 8;
+
+	case 0x051B: {
+		if (CommandSize != 12) {
+			return false;
+		}
+
+		const uint16_t Offset = ReadUint16(&pCommand[4]);
+		const uint8_t Size = pCommand[6];
+
+		return Size <= UART_PROTOCOL_READ_MAX_SIZE && IsEepromRangeValid(Offset, Size);
+	}
+
+	case 0x051D: {
+		if (CommandSize < 12) {
+			return false;
+		}
+
+		const uint16_t Offset = ReadUint16(&pCommand[4]);
+		const uint8_t Size = pCommand[6];
+
+		return CommandSize == (uint16_t)(12U + Size) && Size <= UART_PROTOCOL_WRITE_MAX_SIZE && Size % UART_PROTOCOL_WRITE_BLOCK_SIZE == 0 && Offset % UART_PROTOCOL_WRITE_BLOCK_SIZE == 0 && IsEepromRangeValid(Offset, Size);
+	}
+
+	case 0x052D:
+		return CommandSize == 20;
+
+	case 0x051F:
+	case 0x0521:
+	case 0x0527:
+	case 0x0529:
+	case 0x05DD:
+		return CommandSize == 4;
+	}
+
+	return false;
+}
+
+UART_PROTOCOL_FrameResult_t UART_PROTOCOL_ParseFrame(
+    const uint8_t* pRingBuffer,
+    uint16_t RingBufferSize,
+    uint16_t ReadIndex,
+    uint16_t WriteIndex,
+    bool bIsEncrypted,
+    uint8_t* pCommand,
+    uint16_t CommandCapacity,
+    uint16_t* pNextReadIndex,
+    uint16_t* pCommandSize,
+    bool* pNextIsEncrypted)
+{
+	uint16_t Available;
+	uint16_t CRC;
+	uint16_t ID;
+	uint16_t Index;
+	uint16_t PayloadIndex;
+	uint16_t Size;
+	uint16_t i;
+	uint32_t FrameSize;
+	bool bFrameIsEncrypted;
+
+	*pNextReadIndex = ReadIndex;
+	*pCommandSize = 0;
+	*pNextIsEncrypted = bIsEncrypted;
+
+	if (RingBufferSize == 0 || ReadIndex >= RingBufferSize || WriteIndex >= RingBufferSize) {
+		return UART_PROTOCOL_FRAME_INVALID;
+	}
+
+	Index = ReadIndex;
+	while (Index != WriteIndex) {
+		if (pRingBuffer[Index] != 0xABU) {
+			Index = AddRingIndex(Index, 1, RingBufferSize);
+			continue;
+		}
+
+		Available = GetRingDistance(Index, WriteIndex, RingBufferSize);
+		if (Available < 2) {
+			*pNextReadIndex = Index;
+			return UART_PROTOCOL_FRAME_INCOMPLETE;
+		}
+		if (pRingBuffer[AddRingIndex(Index, 1, RingBufferSize)] != 0xCDU) {
+			Index = AddRingIndex(Index, 1, RingBufferSize);
+			continue;
+		}
+		if (Available < 4) {
+			*pNextReadIndex = Index;
+			return UART_PROTOCOL_FRAME_INCOMPLETE;
+		}
+
+		Size = ReadRingUint16(pRingBuffer, RingBufferSize, AddRingIndex(Index, 2, RingBufferSize));
+		FrameSize = Size + 8U;
+		if (FrameSize > RingBufferSize || Size + 2U > CommandCapacity) {
+			*pNextReadIndex = AddRingIndex(Index, 1, RingBufferSize);
+			return UART_PROTOCOL_FRAME_INVALID;
+		}
+		if (Available < FrameSize) {
+			*pNextReadIndex = Index;
+			return UART_PROTOCOL_FRAME_INCOMPLETE;
+		}
+
+		PayloadIndex = AddRingIndex(Index, 4, RingBufferSize);
+		if (pRingBuffer[AddRingIndex(PayloadIndex, Size + 2U, RingBufferSize)] != 0xDCU || pRingBuffer[AddRingIndex(PayloadIndex, Size + 3U, RingBufferSize)] != 0xBAU) {
+			*pNextReadIndex = AddRingIndex(Index, 1, RingBufferSize);
+			return UART_PROTOCOL_FRAME_INVALID;
+		}
+
+		for (i = 0; i < Size + 2U; i++) {
+			pCommand[i] = pRingBuffer[AddRingIndex(PayloadIndex, i, RingBufferSize)];
+		}
+		*pNextReadIndex = AddRingIndex(Index, (uint16_t)FrameSize, RingBufferSize);
+
+		bFrameIsEncrypted = bIsEncrypted;
+		if (Size >= 2) {
+			ID = ReadUint16(pCommand);
+			if (ID == 0x0514) {
+				bFrameIsEncrypted = false;
+			} else if (ID == 0x6902) {
+				bFrameIsEncrypted = true;
+			}
+		}
+
+		if (bFrameIsEncrypted) {
+			for (i = 0; i < Size + 2U; i++) {
+				pCommand[i] ^= Obfuscation[i % sizeof(Obfuscation)];
+			}
+		}
+
+		CRC = ReadUint16(&pCommand[Size]);
+		if (CRC_Calculate(pCommand, Size) != CRC) {
+			return UART_PROTOCOL_FRAME_INVALID;
+		}
+		if (!UART_PROTOCOL_ValidateCommand(pCommand, Size)) {
+			return UART_PROTOCOL_FRAME_INVALID;
+		}
+
+		*pCommandSize = Size;
+		*pNextIsEncrypted = bFrameIsEncrypted;
+		return UART_PROTOCOL_FRAME_COMMAND;
+	}
+
+	*pNextReadIndex = Index;
+	return UART_PROTOCOL_FRAME_INCOMPLETE;
+}

--- a/app/uart_protocol.c
+++ b/app/uart_protocol.c
@@ -120,6 +120,7 @@ UART_PROTOCOL_FrameResult_t UART_PROTOCOL_ParseFrame(
 	uint16_t CRC;
 	uint16_t ID;
 	uint16_t Index;
+	uint16_t PayloadSize;
 	uint16_t PayloadIndex;
 	uint16_t Size;
 	uint16_t i;
@@ -157,7 +158,12 @@ UART_PROTOCOL_FrameResult_t UART_PROTOCOL_ParseFrame(
 
 		Size	  = ReadRingUint16(pRingBuffer, RingBufferSize, AddRingIndex(Index, 2, RingBufferSize));
 		FrameSize = Size + 8U;
-		if (FrameSize > RingBufferSize || Size + 2U > CommandCapacity) {
+		if (FrameSize > RingBufferSize) {
+			*pNextReadIndex = AddRingIndex(Index, 1, RingBufferSize);
+			return UART_PROTOCOL_FRAME_INVALID;
+		}
+		PayloadSize = (uint16_t)(Size + 2U);
+		if (PayloadSize > CommandCapacity) {
 			*pNextReadIndex = AddRingIndex(Index, 1, RingBufferSize);
 			return UART_PROTOCOL_FRAME_INVALID;
 		}
@@ -172,7 +178,7 @@ UART_PROTOCOL_FrameResult_t UART_PROTOCOL_ParseFrame(
 			return UART_PROTOCOL_FRAME_INVALID;
 		}
 
-		for (i = 0; i < Size + 2U; i++) {
+		for (i = 0; i < PayloadSize; i++) {
 			pCommand[i] = pRingBuffer[AddRingIndex(PayloadIndex, i, RingBufferSize)];
 		}
 		*pNextReadIndex = AddRingIndex(Index, (uint16_t)FrameSize, RingBufferSize);
@@ -188,7 +194,7 @@ UART_PROTOCOL_FrameResult_t UART_PROTOCOL_ParseFrame(
 		}
 
 		if (bFrameIsEncrypted) {
-			for (i = 0; i < Size + 2U; i++) {
+			for (i = 0; i < PayloadSize; i++) {
 				pCommand[i] ^= Obfuscation[i % sizeof(Obfuscation)];
 			}
 		}

--- a/app/uart_protocol.c
+++ b/app/uart_protocol.c
@@ -17,7 +17,7 @@
 #include "app/uart_protocol.h"
 #include "driver/crc.h"
 
-static const uint8_t Obfuscation[16] = {0x16, 0x6C, 0x14, 0xE6, 0x2E, 0x91, 0x0D, 0x40, 0x21, 0x35, 0xD5, 0x40, 0x13, 0x03, 0xE9, 0x80};
+static const uint8_t Obfuscation[16] = { 0x16, 0x6C, 0x14, 0xE6, 0x2E, 0x91, 0x0D, 0x40, 0x21, 0x35, 0xD5, 0x40, 0x13, 0x03, 0xE9, 0x80 };
 
 static uint16_t AddRingIndex(uint16_t Index, uint16_t Amount, uint16_t RingBufferSize)
 {
@@ -33,12 +33,12 @@ static uint16_t GetRingDistance(uint16_t Start, uint16_t End, uint16_t RingBuffe
 	return (RingBufferSize - Start) + End;
 }
 
-static uint16_t ReadUint16(const uint8_t* pData)
+static uint16_t ReadUint16(const uint8_t *pData)
 {
 	return pData[0] | ((uint16_t)pData[1] << 8);
 }
 
-static uint16_t ReadRingUint16(const uint8_t* pRingBuffer, uint16_t RingBufferSize, uint16_t Index)
+static uint16_t ReadRingUint16(const uint8_t *pRingBuffer, uint16_t RingBufferSize, uint16_t Index)
 {
 	return pRingBuffer[Index] | ((uint16_t)pRingBuffer[AddRingIndex(Index, 1, RingBufferSize)] << 8);
 }
@@ -48,7 +48,7 @@ static bool IsEepromRangeValid(uint16_t Offset, uint16_t Size)
 	return Size > 0 && (uint32_t)Offset + Size <= UART_PROTOCOL_EEPROM_SIZE;
 }
 
-bool UART_PROTOCOL_ValidateCommand(const uint8_t* pCommand, uint16_t CommandSize)
+bool UART_PROTOCOL_ValidateCommand(const uint8_t *pCommand, uint16_t CommandSize)
 {
 	uint16_t ID;
 	uint16_t HeaderSize;
@@ -57,7 +57,7 @@ bool UART_PROTOCOL_ValidateCommand(const uint8_t* pCommand, uint16_t CommandSize
 		return false;
 	}
 
-	ID = ReadUint16(&pCommand[0]);
+	ID	   = ReadUint16(&pCommand[0]);
 	HeaderSize = ReadUint16(&pCommand[2]);
 	if (HeaderSize != CommandSize - 4U) {
 		return false;
@@ -74,7 +74,7 @@ bool UART_PROTOCOL_ValidateCommand(const uint8_t* pCommand, uint16_t CommandSize
 		}
 
 		const uint16_t Offset = ReadUint16(&pCommand[4]);
-		const uint8_t Size = pCommand[6];
+		const uint8_t Size    = pCommand[6];
 
 		return Size <= UART_PROTOCOL_READ_MAX_SIZE && IsEepromRangeValid(Offset, Size);
 	}
@@ -85,7 +85,7 @@ bool UART_PROTOCOL_ValidateCommand(const uint8_t* pCommand, uint16_t CommandSize
 		}
 
 		const uint16_t Offset = ReadUint16(&pCommand[4]);
-		const uint8_t Size = pCommand[6];
+		const uint8_t Size    = pCommand[6];
 
 		return CommandSize == (uint16_t)(12U + Size) && Size <= UART_PROTOCOL_WRITE_MAX_SIZE && Size % UART_PROTOCOL_WRITE_BLOCK_SIZE == 0 && Offset % UART_PROTOCOL_WRITE_BLOCK_SIZE == 0 && IsEepromRangeValid(Offset, Size);
 	}
@@ -105,16 +105,16 @@ bool UART_PROTOCOL_ValidateCommand(const uint8_t* pCommand, uint16_t CommandSize
 }
 
 UART_PROTOCOL_FrameResult_t UART_PROTOCOL_ParseFrame(
-    const uint8_t* pRingBuffer,
-    uint16_t RingBufferSize,
-    uint16_t ReadIndex,
-    uint16_t WriteIndex,
-    bool bIsEncrypted,
-    uint8_t* pCommand,
-    uint16_t CommandCapacity,
-    uint16_t* pNextReadIndex,
-    uint16_t* pCommandSize,
-    bool* pNextIsEncrypted)
+	const uint8_t *pRingBuffer,
+	uint16_t RingBufferSize,
+	uint16_t ReadIndex,
+	uint16_t WriteIndex,
+	bool bIsEncrypted,
+	uint8_t *pCommand,
+	uint16_t CommandCapacity,
+	uint16_t *pNextReadIndex,
+	uint16_t *pCommandSize,
+	bool *pNextIsEncrypted)
 {
 	uint16_t Available;
 	uint16_t CRC;
@@ -126,8 +126,8 @@ UART_PROTOCOL_FrameResult_t UART_PROTOCOL_ParseFrame(
 	uint32_t FrameSize;
 	bool bFrameIsEncrypted;
 
-	*pNextReadIndex = ReadIndex;
-	*pCommandSize = 0;
+	*pNextReadIndex	  = ReadIndex;
+	*pCommandSize	  = 0;
 	*pNextIsEncrypted = bIsEncrypted;
 
 	if (RingBufferSize == 0 || ReadIndex >= RingBufferSize || WriteIndex >= RingBufferSize) {
@@ -155,7 +155,7 @@ UART_PROTOCOL_FrameResult_t UART_PROTOCOL_ParseFrame(
 			return UART_PROTOCOL_FRAME_INCOMPLETE;
 		}
 
-		Size = ReadRingUint16(pRingBuffer, RingBufferSize, AddRingIndex(Index, 2, RingBufferSize));
+		Size	  = ReadRingUint16(pRingBuffer, RingBufferSize, AddRingIndex(Index, 2, RingBufferSize));
 		FrameSize = Size + 8U;
 		if (FrameSize > RingBufferSize || Size + 2U > CommandCapacity) {
 			*pNextReadIndex = AddRingIndex(Index, 1, RingBufferSize);
@@ -201,7 +201,7 @@ UART_PROTOCOL_FrameResult_t UART_PROTOCOL_ParseFrame(
 			return UART_PROTOCOL_FRAME_INVALID;
 		}
 
-		*pCommandSize = Size;
+		*pCommandSize	  = Size;
 		*pNextIsEncrypted = bFrameIsEncrypted;
 		return UART_PROTOCOL_FRAME_COMMAND;
 	}

--- a/app/uart_protocol.h
+++ b/app/uart_protocol.h
@@ -1,0 +1,52 @@
+/* Copyright 2023 Dual Tachyon
+ * https://github.com/DualTachyon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef APP_UART_PROTOCOL_H
+#define APP_UART_PROTOCOL_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+enum
+{
+	UART_PROTOCOL_EEPROM_SIZE = 0x2000,
+	UART_PROTOCOL_READ_MAX_SIZE = 128,
+	UART_PROTOCOL_WRITE_MAX_SIZE = 128,
+	UART_PROTOCOL_WRITE_BLOCK_SIZE = 8,
+};
+
+typedef enum
+{
+	UART_PROTOCOL_FRAME_INCOMPLETE,
+	UART_PROTOCOL_FRAME_INVALID,
+	UART_PROTOCOL_FRAME_COMMAND,
+} UART_PROTOCOL_FrameResult_t;
+
+bool UART_PROTOCOL_ValidateCommand(const uint8_t* pCommand, uint16_t CommandSize);
+
+UART_PROTOCOL_FrameResult_t UART_PROTOCOL_ParseFrame(
+    const uint8_t* pRingBuffer,
+    uint16_t RingBufferSize,
+    uint16_t ReadIndex,
+    uint16_t WriteIndex,
+    bool bIsEncrypted,
+    uint8_t* pCommand,
+    uint16_t CommandCapacity,
+    uint16_t* pNextReadIndex,
+    uint16_t* pCommandSize,
+    bool* pNextIsEncrypted);
+
+#endif

--- a/app/uart_protocol.h
+++ b/app/uart_protocol.h
@@ -20,33 +20,31 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-enum
-{
-	UART_PROTOCOL_EEPROM_SIZE = 0x2000,
-	UART_PROTOCOL_READ_MAX_SIZE = 128,
-	UART_PROTOCOL_WRITE_MAX_SIZE = 128,
+enum {
+	UART_PROTOCOL_EEPROM_SIZE      = 0x2000,
+	UART_PROTOCOL_READ_MAX_SIZE    = 128,
+	UART_PROTOCOL_WRITE_MAX_SIZE   = 128,
 	UART_PROTOCOL_WRITE_BLOCK_SIZE = 8,
 };
 
-typedef enum
-{
+typedef enum {
 	UART_PROTOCOL_FRAME_INCOMPLETE,
 	UART_PROTOCOL_FRAME_INVALID,
 	UART_PROTOCOL_FRAME_COMMAND,
 } UART_PROTOCOL_FrameResult_t;
 
-bool UART_PROTOCOL_ValidateCommand(const uint8_t* pCommand, uint16_t CommandSize);
+bool UART_PROTOCOL_ValidateCommand(const uint8_t *pCommand, uint16_t CommandSize);
 
 UART_PROTOCOL_FrameResult_t UART_PROTOCOL_ParseFrame(
-    const uint8_t* pRingBuffer,
-    uint16_t RingBufferSize,
-    uint16_t ReadIndex,
-    uint16_t WriteIndex,
-    bool bIsEncrypted,
-    uint8_t* pCommand,
-    uint16_t CommandCapacity,
-    uint16_t* pNextReadIndex,
-    uint16_t* pCommandSize,
-    bool* pNextIsEncrypted);
+	const uint8_t *pRingBuffer,
+	uint16_t RingBufferSize,
+	uint16_t ReadIndex,
+	uint16_t WriteIndex,
+	bool bIsEncrypted,
+	uint8_t *pCommand,
+	uint16_t CommandCapacity,
+	uint16_t *pNextReadIndex,
+	uint16_t *pCommandSize,
+	bool *pNextIsEncrypted);
 
 #endif

--- a/tests/test_uart_protocol.py
+++ b/tests/test_uart_protocol.py
@@ -1,0 +1,244 @@
+import shutil
+import struct
+import subprocess
+from binascii import crc_hqx
+from itertools import cycle
+from pathlib import Path
+
+import pytest
+
+
+OBFUSCATION = bytes(
+    [
+        0x16,
+        0x6C,
+        0x14,
+        0xE6,
+        0x2E,
+        0x91,
+        0x0D,
+        0x40,
+        0x21,
+        0x35,
+        0xD5,
+        0x40,
+        0x13,
+        0x03,
+        0xE9,
+        0x80,
+    ]
+)
+
+
+def command(command_id, body=b"", header_size=None):
+    if header_size is None:
+        header_size = len(body)
+    return struct.pack("<HH", command_id, header_size) + body
+
+
+def read_command(offset=0, size=128, header_size=None):
+    body = struct.pack("<HBBI", offset, size, 0, 0x6457396A)
+    return command(0x051B, body, header_size)
+
+
+def write_command(offset=0, data=b"\x00" * 128, declared_size=None, header_size=None):
+    if declared_size is None:
+        declared_size = len(data)
+    body = struct.pack("<HBBI", offset, declared_size, 1, 0x6457396A) + data
+    return command(0x051D, body, header_size)
+
+
+def frame(payload, encrypted=True, corrupt_crc=False):
+    crc = crc_hqx(payload, 0)
+    if corrupt_crc:
+        crc ^= 0x0001
+    encoded = payload + struct.pack("<H", crc)
+    if encrypted:
+        encoded = bytes(value ^ key for value, key in zip(encoded, cycle(OBFUSCATION)))
+    return b"\xAB\xCD" + struct.pack("<H", len(payload)) + encoded + b"\xDC\xBA"
+
+
+@pytest.fixture(scope="session")
+def uart_harness(tmp_path_factory):
+    compiler = shutil.which("gcc")
+    if compiler is None:
+        pytest.skip("gcc is required for UART protocol host tests")
+
+    executable = tmp_path_factory.mktemp("uart_protocol") / "uart_protocol_harness"
+    root = Path(__file__).resolve().parents[1]
+    subprocess.run(
+        [
+            compiler,
+            "-std=c11",
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            "-I",
+            str(root),
+            str(root / "tests" / "uart_protocol_harness.c"),
+            str(root / "app" / "uart_protocol.c"),
+            "-o",
+            str(executable),
+        ],
+        check=True,
+    )
+    return executable
+
+
+def validate(uart_harness, payload):
+    result = subprocess.run(
+        [str(uart_harness), "validate", payload.hex()],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() == "1"
+
+
+def parse(uart_harness, packet, ring_size=256, start=0, encrypted=True):
+    result = subprocess.run(
+        [
+            str(uart_harness),
+            "parse",
+            packet.hex(),
+            str(ring_size),
+            str(start),
+            str(int(encrypted)),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    frame_result, next_index, command_size, next_encrypted, command_id = result.stdout.split()
+    return {
+        "result": int(frame_result),
+        "next_index": int(next_index),
+        "command_size": int(command_size),
+        "encrypted": bool(int(next_encrypted)),
+        "command_id": int(command_id, 16),
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        command(0x0514, struct.pack("<I", 0x6457396A)),
+        read_command(),
+        write_command(),
+        command(0x0527),
+        command(0x0529),
+        command(0x052D, b"\x00" * 16),
+        command(0x052F, struct.pack("<I", 0x6457396A)),
+        command(0x05DD),
+    ],
+)
+def test_valid_command_shapes(uart_harness, payload):
+    assert validate(uart_harness, payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"\x1B\x05\x08",
+        command(0x051B),
+        command(0x051D),
+        read_command(header_size=7),
+        read_command(size=0),
+        read_command(size=129),
+        read_command(offset=0x1FC0, size=128),
+        read_command(offset=0xFFF0, size=32),
+        write_command(offset=1),
+        write_command(data=b"\x00" * 7),
+        write_command(data=b"\x00" * 136),
+        write_command(data=b"\x00" * 8, declared_size=16),
+        write_command(offset=0x1FF8, data=b"\x00" * 16),
+        command(0x052F),
+        command(0x05DD, b"\x00"),
+        command(0xFFFF),
+    ],
+)
+def test_malformed_and_out_of_range_commands_are_rejected(uart_harness, payload):
+    assert not validate(uart_harness, payload)
+
+
+def test_encrypted_frame_parses_across_ring_wrap(uart_harness):
+    payload = read_command(offset=0x1F80)
+    packet = frame(payload)
+
+    parsed = parse(uart_harness, packet, ring_size=64, start=55)
+
+    assert parsed == {
+        "result": 2,
+        "next_index": (55 + len(packet)) % 64,
+        "command_size": len(payload),
+        "encrypted": True,
+        "command_id": 0x051B,
+    }
+
+
+def test_bad_crc_is_consumed_without_dispatch(uart_harness):
+    packet = frame(read_command(), corrupt_crc=True)
+
+    parsed = parse(uart_harness, packet)
+
+    assert parsed["result"] == 1
+    assert parsed["next_index"] == len(packet)
+    assert parsed["command_size"] == 0
+
+
+def test_truncated_frame_waits_for_remaining_bytes(uart_harness):
+    packet = frame(write_command(data=b"\x00" * 8))[:-1]
+
+    parsed = parse(uart_harness, packet)
+
+    assert parsed["result"] == 0
+    assert parsed["next_index"] == 0
+    assert parsed["command_size"] == 0
+
+
+def test_oversized_outer_frame_is_rejected(uart_harness):
+    parsed = parse(uart_harness, b"\xAB\xCD\xFF\xFF")
+
+    assert parsed["result"] == 1
+    assert parsed["next_index"] == 1
+    assert parsed["command_size"] == 0
+
+
+def test_invalid_eeprom_frame_is_consumed_without_dispatch(uart_harness):
+    packet = frame(write_command(offset=0x1FF8, data=b"\x00" * 16))
+
+    parsed = parse(uart_harness, packet)
+
+    assert parsed["result"] == 1
+    assert parsed["next_index"] == len(packet)
+    assert parsed["command_size"] == 0
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        command(0x052F),
+        command(0x05DD, b"\x00"),
+    ],
+)
+def test_malformed_state_changing_frames_cannot_dispatch(uart_harness, payload):
+    parsed = parse(uart_harness, frame(payload))
+
+    assert parsed["result"] == 1
+    assert parsed["command_size"] == 0
+
+
+def test_valid_plaintext_hello_changes_encryption_only_after_crc(uart_harness):
+    hello = command(0x0514, struct.pack("<I", 0x6457396A))
+
+    valid = parse(uart_harness, frame(hello, encrypted=False), encrypted=True)
+    invalid = parse(
+        uart_harness,
+        frame(hello, encrypted=False, corrupt_crc=True),
+        encrypted=True,
+    )
+
+    assert valid["result"] == 2
+    assert valid["encrypted"] is False
+    assert invalid["result"] == 1
+    assert invalid["encrypted"] is True

--- a/tests/uart_protocol_harness.c
+++ b/tests/uart_protocol_harness.c
@@ -6,10 +6,10 @@
 
 #include "app/uart_protocol.h"
 
-uint16_t CRC_Calculate(const void* pBuffer, uint16_t Size)
+uint16_t CRC_Calculate(const void *pBuffer, uint16_t Size)
 {
-	const uint8_t* pData = pBuffer;
-	uint16_t CRC = 0;
+	const uint8_t *pData = pBuffer;
+	uint16_t CRC	     = 0;
 	uint16_t i;
 	uint8_t Bit;
 
@@ -42,7 +42,7 @@ static int HexValue(char Value)
 	return -1;
 }
 
-static int DecodeHex(const char* pHex, uint8_t* pOutput, size_t OutputCapacity)
+static int DecodeHex(const char *pHex, uint8_t *pOutput, size_t OutputCapacity)
 {
 	const size_t HexLength = strlen(pHex);
 	size_t i;
@@ -53,7 +53,7 @@ static int DecodeHex(const char* pHex, uint8_t* pOutput, size_t OutputCapacity)
 
 	for (i = 0; i < HexLength / 2; i++) {
 		const int High = HexValue(pHex[i * 2]);
-		const int Low = HexValue(pHex[(i * 2) + 1]);
+		const int Low  = HexValue(pHex[(i * 2) + 1]);
 
 		if (High < 0 || Low < 0) {
 			return -1;
@@ -64,7 +64,7 @@ static int DecodeHex(const char* pHex, uint8_t* pOutput, size_t OutputCapacity)
 	return (int)(HexLength / 2);
 }
 
-static int ValidateCommand(const char* pHex)
+static int ValidateCommand(const char *pHex)
 {
 	uint8_t Command[256];
 	const int CommandSize = DecodeHex(pHex, Command, sizeof(Command));
@@ -77,15 +77,15 @@ static int ValidateCommand(const char* pHex)
 	return 0;
 }
 
-static int ParseFrame(const char* pHex, const char* pRingSizeText, const char* pStartText, const char* pEncryptedText)
+static int ParseFrame(const char *pHex, const char *pRingSizeText, const char *pStartText, const char *pEncryptedText)
 {
 	uint8_t Frame[256];
-	uint8_t RingBuffer[256] = {0};
-	uint8_t Command[256] = {0};
-	const int FrameLength = DecodeHex(pHex, Frame, sizeof(Frame));
+	uint8_t RingBuffer[256]	      = { 0 };
+	uint8_t Command[256]	      = { 0 };
+	const int FrameLength	      = DecodeHex(pHex, Frame, sizeof(Frame));
 	const uint16_t RingBufferSize = (uint16_t)strtoul(pRingSizeText, NULL, 0);
-	const uint16_t Start = (uint16_t)strtoul(pStartText, NULL, 0);
-	const bool bIsEncrypted = strtoul(pEncryptedText, NULL, 0) != 0;
+	const uint16_t Start	      = (uint16_t)strtoul(pStartText, NULL, 0);
+	const bool bIsEncrypted	      = strtoul(pEncryptedText, NULL, 0) != 0;
 	uint16_t CommandSize;
 	uint16_t NextReadIndex;
 	uint16_t WriteIndex;
@@ -103,22 +103,22 @@ static int ParseFrame(const char* pHex, const char* pRingSizeText, const char* p
 	WriteIndex = (Start + FrameLength) % RingBufferSize;
 
 	Result = UART_PROTOCOL_ParseFrame(
-	    RingBuffer,
-	    RingBufferSize,
-	    Start,
-	    WriteIndex,
-	    bIsEncrypted,
-	    Command,
-	    sizeof(Command),
-	    &NextReadIndex,
-	    &CommandSize,
-	    &bNextIsEncrypted);
+		RingBuffer,
+		RingBufferSize,
+		Start,
+		WriteIndex,
+		bIsEncrypted,
+		Command,
+		sizeof(Command),
+		&NextReadIndex,
+		&CommandSize,
+		&bNextIsEncrypted);
 
 	printf("%u %u %u %u %04X\n", Result, NextReadIndex, CommandSize, bNextIsEncrypted, CommandSize >= 2 ? Command[0] | (Command[1] << 8) : 0);
 	return 0;
 }
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
 	if (argc == 3 && strcmp(argv[1], "validate") == 0) {
 		return ValidateCommand(argv[2]);

--- a/tests/uart_protocol_harness.c
+++ b/tests/uart_protocol_harness.c
@@ -1,0 +1,131 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "app/uart_protocol.h"
+
+uint16_t CRC_Calculate(const void* pBuffer, uint16_t Size)
+{
+	const uint8_t* pData = pBuffer;
+	uint16_t CRC = 0;
+	uint16_t i;
+	uint8_t Bit;
+
+	for (i = 0; i < Size; i++) {
+		CRC ^= (uint16_t)pData[i] << 8;
+		for (Bit = 0; Bit < 8; Bit++) {
+			if ((CRC & 0x8000U) != 0) {
+				CRC = (CRC << 1) ^ 0x1021U;
+			} else {
+				CRC <<= 1;
+			}
+		}
+	}
+
+	return CRC;
+}
+
+static int HexValue(char Value)
+{
+	if (Value >= '0' && Value <= '9') {
+		return Value - '0';
+	}
+	if (Value >= 'a' && Value <= 'f') {
+		return Value - 'a' + 10;
+	}
+	if (Value >= 'A' && Value <= 'F') {
+		return Value - 'A' + 10;
+	}
+
+	return -1;
+}
+
+static int DecodeHex(const char* pHex, uint8_t* pOutput, size_t OutputCapacity)
+{
+	const size_t HexLength = strlen(pHex);
+	size_t i;
+
+	if (HexLength % 2 != 0 || HexLength / 2 > OutputCapacity) {
+		return -1;
+	}
+
+	for (i = 0; i < HexLength / 2; i++) {
+		const int High = HexValue(pHex[i * 2]);
+		const int Low = HexValue(pHex[(i * 2) + 1]);
+
+		if (High < 0 || Low < 0) {
+			return -1;
+		}
+		pOutput[i] = (High << 4) | Low;
+	}
+
+	return (int)(HexLength / 2);
+}
+
+static int ValidateCommand(const char* pHex)
+{
+	uint8_t Command[256];
+	const int CommandSize = DecodeHex(pHex, Command, sizeof(Command));
+
+	if (CommandSize < 0) {
+		return 2;
+	}
+
+	printf("%u\n", UART_PROTOCOL_ValidateCommand(Command, CommandSize));
+	return 0;
+}
+
+static int ParseFrame(const char* pHex, const char* pRingSizeText, const char* pStartText, const char* pEncryptedText)
+{
+	uint8_t Frame[256];
+	uint8_t RingBuffer[256] = {0};
+	uint8_t Command[256] = {0};
+	const int FrameLength = DecodeHex(pHex, Frame, sizeof(Frame));
+	const uint16_t RingBufferSize = (uint16_t)strtoul(pRingSizeText, NULL, 0);
+	const uint16_t Start = (uint16_t)strtoul(pStartText, NULL, 0);
+	const bool bIsEncrypted = strtoul(pEncryptedText, NULL, 0) != 0;
+	uint16_t CommandSize;
+	uint16_t NextReadIndex;
+	uint16_t WriteIndex;
+	uint16_t i;
+	bool bNextIsEncrypted;
+	UART_PROTOCOL_FrameResult_t Result;
+
+	if (FrameLength < 0 || RingBufferSize == 0 || RingBufferSize > sizeof(RingBuffer) || Start >= RingBufferSize || FrameLength >= RingBufferSize) {
+		return 2;
+	}
+
+	for (i = 0; i < (uint16_t)FrameLength; i++) {
+		RingBuffer[(Start + i) % RingBufferSize] = Frame[i];
+	}
+	WriteIndex = (Start + FrameLength) % RingBufferSize;
+
+	Result = UART_PROTOCOL_ParseFrame(
+	    RingBuffer,
+	    RingBufferSize,
+	    Start,
+	    WriteIndex,
+	    bIsEncrypted,
+	    Command,
+	    sizeof(Command),
+	    &NextReadIndex,
+	    &CommandSize,
+	    &bNextIsEncrypted);
+
+	printf("%u %u %u %u %04X\n", Result, NextReadIndex, CommandSize, bNextIsEncrypted, CommandSize >= 2 ? Command[0] | (Command[1] << 8) : 0);
+	return 0;
+}
+
+int main(int argc, char** argv)
+{
+	if (argc == 3 && strcmp(argv[1], "validate") == 0) {
+		return ValidateCommand(argv[2]);
+	}
+	if (argc == 6 && strcmp(argv[1], "parse") == 0) {
+		return ParseFrame(argv[2], argv[3], argv[4], argv[5]);
+	}
+
+	return 2;
+}


### PR DESCRIPTION
## Summary

- extract the UART ring-buffer/frame decoder into a host-testable protocol module
- reject bad CRCs, truncated or inconsistent commands, oversized transfers, and invalid EEPROM ranges before dispatch
- cap CHIRP transfers at 128 bytes, require 8-byte-aligned writes, and zero-initialize all reply padding
- add regression coverage for ring wrap, truncated and oversized frames, bad CRCs, invalid EEPROM access, and malformed state-changing commands

## Validation

- `pytest -q` — 34 passed
- `CI_MODE=cppcheck ./ci/run.sh`
- ARM firmware build — 51,416 bytes (122,880-byte limit)
- AddressSanitizer/UBSan truncated-prefix checks
- CHIRP compatibility probe
- CHIRP UV-K5 driver tests — 99 passed, 24 skipped, 3 xfailed, 3 xpassed

Hardware UART/CHIRP validation remains before marking this ready for review.

Closes #36