### PR TITLE
Make formatting checks reproducible

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,17 +1,18 @@
 BasedOnStyle: LLVM
 IndentWidth: 8
+ContinuationIndentWidth: 8
 TabWidth: 8
 UseTab: Always
 BreakBeforeBraces: Custom
 BraceWrapping:
   AfterFunction: true
-  AfterClass: true
-  AfterStruct: true
+  AfterClass: false
+  AfterStruct: false
   AfterControlStatement: false
   BeforeElse: false
   BeforeCatch: false
-  AfterEnum: true
-  AfterNamespace: true
+  AfterEnum: false
+  AfterNamespace: false
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
@@ -19,7 +20,10 @@ AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AllowShortBlocksOnASingleLine: Never
 ColumnLimit: 0
-PointerAlignment: Left
+PointerAlignment: Right
+DerivePointerAlignment: false
+AlignConsecutiveAssignments: Consecutive
+Cpp11BracedListStyle: false
 SpaceBeforeParens: ControlStatements
 SpacesBeforeTrailingComments: 1
 IndentCaseLabels: false

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,7 +35,7 @@ jobs:
         run: python -m ruff check fw-pack.py tests
 
       - name: Shellcheck
-        run: shellcheck compile-with-docker.sh ci/run.sh
+        run: shellcheck compile-with-docker.sh ci/run.sh ci/check-clang-format.sh
 
   clang-format:
     runs-on: ubuntu-22.04
@@ -46,10 +46,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install clang-format
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-format
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pinned clang-format
+        run: python -m pip install -r ci/requirements-format.txt
 
       - name: Check formatting
         run: ci/check-clang-format.sh

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -131,6 +131,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           submodules: recursive
 
       - name: Derive version suffix

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           submodules: recursive
 
       - name: Derive version suffix

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,13 +13,14 @@
 - `python3 fw-pack.py loaner-firmware.bin AUTHOR VERSION loaner-firmware.packed.bin` injects metadata so web flashers accept the build.
 
 ## Coding Style & Naming Conventions
-- Indent with tabs and place braces on the following line (Allman style); macros remain uppercase snake-case (`ENABLE_*`, `SYSCON_*`).
-- Follow existing naming: module globals use leading capitals (`gScreenLine`), static helpers stay lower_case, and files compile as C2x.
+- Indent with tabs; macros remain uppercase snake-case (`ENABLE_*`, `SYSCON_*`).
+- Use same-line opening braces for enums and structs, next-line opening braces for functions, and same-line braces for control statements. Declare pointers as `Type *name`, indent initializer elements by one tab, and column-align consecutive assignments.
+- Follow existing naming: module globals use leading capitals (`gScreenLine`), static helpers stay lower_case, and files compile as C11.
 - Order includes from local headers outward and wrap optional code in the matching `#ifdef ENABLE_*` guard.
 - Treat `-Werror` seriously—run `make` locally to keep the build warning-free.
 
 ## Testing Guidelines
-- No automated suite ships here; always compile locally and validate the affected features on hardware.
+- Run `pytest -q`, the changed-line clang-format check, cppcheck, and an ARM build before opening a pull request.
 - Perform smoke tests covering boot, menu navigation, audio, and any toggled `ENABLE_*` feature; log RF observations for signal work.
 - Record the manual steps and outcomes in your pull request to help reviewers reproduce them.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -45,8 +45,9 @@ python3 fw-pack.py loaner-firmware.bin LNR2415 loaner-firmware.packed.bin
 - The packed image is required for PC loader flashing because it carries the metadata Quansheng's tool expects.
 
 ## Running Lint and Tests
-- `./compile-with-docker.sh` already executes `ci/run.sh`, so every Docker build runs cppcheck, pytest, and the firmware build in one shot.
-- GitHub Actions runs dedicated lint stages before building: a style job (`ruff` over the Python tooling and `shellcheck` over the scripts), a `clang-format` diff check on C/C++ changes, and a `cppcheck` pass on the firmware sources. Fix issues reported there before kicking off full builds. To run the format check locally, export the same diff and pipe it into `clang-format-diff -p1`.
+- `./compile-with-docker.sh` already executes `ci/run.sh`, so every Docker build runs the changed-line format check, cppcheck, pytest, and the firmware build in one shot.
+- GitHub Actions and the Docker image both install clang-format 14.0.6 from `ci/requirements-format.txt` and invoke `ci/check-clang-format.sh`. The check uses a zero-context diff and formats only C lines changed from `origin/main`; existing untouched source is the controlled baseline.
+- For native development, install the pinned formatter with `python -m pip install -r ci/requirements-format.txt`. Run `ci/check-clang-format.sh` to check your changes or `ci/check-clang-format.sh --fix` to apply the canonical style to changed lines. Pass a different base ref as the final argument when needed, for example `ci/check-clang-format.sh --fix origin/release`.
 - A CHIRP compatibility check clones the driver repo (defaulting to our whitelist branch), asserts that the latest `OEFW-LNR…` banner still passes `k5_approve_firmware`, revalidates that the firmware keeps the OEM channel bounds (MR channels 0–199, etc.), and runs a subset of the UV-K5 driver tests (memory edits/settings mutations). Update `COMPAT_SUFFIX` or the tracked CHIRP ref when cutting new releases so uploads keep working.
 - If you are working natively, `ci/run.sh` reproduces the same flow once the dependencies are installed (see the Dockerfile for the package list). Run it with the same suffix to mirror CI:
   ```sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,11 @@ RUN pacman -Syyu --noconfirm \
     curl \
     tar
 
+COPY ci/requirements-format.txt /tmp/requirements-format.txt
+
+RUN python -m pip install --break-system-packages --no-cache-dir \
+    -r /tmp/requirements-format.txt
+
 RUN curl -L "${TOOLCHAIN_URL}" -o "/tmp/${TOOLCHAIN_ARCHIVE}" \
     && tar -xjf "/tmp/${TOOLCHAIN_ARCHIVE}" -C /opt \
     && rm "/tmp/${TOOLCHAIN_ARCHIVE}"

--- a/ci/check-clang-format.sh
+++ b/ci/check-clang-format.sh
@@ -1,8 +1,40 @@
 #!/bin/bash
 set -euo pipefail
 
-if ! command -v clang-format >/dev/null 2>&1; then
-	echo "clang-format not found on PATH" >&2
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REQUIREMENTS="${SCRIPT_DIR}/requirements-format.txt"
+MODE="check"
+
+if [[ "${1:-}" == "--fix" ]]; then
+	MODE="fix"
+	shift
+elif [[ "${1:-}" == "--check" ]]; then
+	shift
+fi
+
+FORMATTER="${CLANG_FORMAT_BIN:-clang-format}"
+FORMAT_DIFF="${CLANG_FORMAT_DIFF_BIN:-clang-format-diff.py}"
+EXPECTED_VERSION="$(sed -n 's/^clang-format==//p' "${REQUIREMENTS}")"
+
+if [[ -z "${EXPECTED_VERSION}" ]]; then
+	echo "Unable to read the pinned clang-format version from ${REQUIREMENTS}" >&2
+	exit 1
+fi
+
+if ! command -v "${FORMATTER}" >/dev/null 2>&1; then
+	echo "${FORMATTER} not found on PATH; install ${REQUIREMENTS}" >&2
+	exit 1
+fi
+
+if ! command -v "${FORMAT_DIFF}" >/dev/null 2>&1; then
+	echo "${FORMAT_DIFF} not found on PATH; install ${REQUIREMENTS}" >&2
+	exit 1
+fi
+
+ACTUAL_VERSION="$("${FORMATTER}" --version)"
+if [[ "${ACTUAL_VERSION}" != *"version ${EXPECTED_VERSION}"* ]]; then
+	echo "Expected clang-format ${EXPECTED_VERSION}, got: ${ACTUAL_VERSION}" >&2
 	exit 1
 fi
 
@@ -13,10 +45,43 @@ else
 	BASE_REF="${1:-origin/main}"
 fi
 
-# Ensure the base ref is available locally.
-git fetch --no-tags --depth=1 origin "${BASE_REF#origin/}" >/dev/null 2>&1 || true
+cd "${ROOT}"
 
-DIFF=$(git diff --diff-filter=ACMRTUXB "${BASE_REF}"... -- '*.c' '*.h' | clang-format-diff -p1)
+if [[ "${BASE_REF}" == origin/* ]]; then
+	git fetch --no-tags origin "${BASE_REF#origin/}" >/dev/null 2>&1 || true
+fi
+
+if ! MERGE_BASE="$(git merge-base "${BASE_REF}" HEAD)"; then
+	echo "Unable to find a merge base for ${BASE_REF}; fetch the base branch and retry" >&2
+	exit 1
+fi
+
+source_diff() {
+	local Path
+	local Status
+
+	git diff -U0 --no-color --relative --diff-filter=ACMRTUXB "${MERGE_BASE}" -- '*.c' '*.h'
+	while IFS= read -r Path; do
+		Status=0
+		git diff --no-index -U0 --no-color -- /dev/null "${Path}" || Status=$?
+		if ((Status > 1)); then
+			return "${Status}"
+		fi
+	done < <(git ls-files --others --exclude-standard -- '*.c' '*.h')
+}
+
+format_diff() {
+	source_diff |
+		"${FORMAT_DIFF}" -p1 -binary "${FORMATTER}" "$@"
+}
+
+if [[ "${MODE}" == "fix" ]]; then
+	format_diff -i
+	echo "clang-format applied to C lines changed from ${BASE_REF}."
+	exit 0
+fi
+
+DIFF="$(format_diff)"
 
 if [[ -n "${DIFF}" ]]; then
 	echo "clang-format diff detected:"
@@ -24,4 +89,4 @@ if [[ -n "${DIFF}" ]]; then
 	exit 1
 fi
 
-echo "clang-format check passed."
+echo "clang-format ${EXPECTED_VERSION} check passed for lines changed from ${BASE_REF}."

--- a/ci/requirements-format.txt
+++ b/ci/requirements-format.txt
@@ -1,0 +1,1 @@
+clang-format==14.0.6

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -53,6 +53,9 @@ fi
 mkdir -p "${ARTIFACT_DIR}"
 rm -f "${ARTIFACT_DIR}"/loaner-firmware*.bin
 
+echo "Checking C formatting..."
+"${ROOT}/ci/check-clang-format.sh"
+
 run_cppcheck
 
 echo "Running unit tests..."


### PR DESCRIPTION
## Summary

- align `.clang-format` with the repository's established C style for pointers, braces, initializers, and assignment alignment
- pin clang-format 14.0.6 for both GitHub Actions and the project Docker image
- check zero-context changed lines from the merge base, including staged, unstaged, and untracked C/header files
- add `ci/check-clang-format.sh --fix` as the matching changed-line autofix command
- run the same format check from the advertised full Docker/CI entrypoint
- document the canonical style and native check/fix commands

## Root cause

The old checker installed whatever clang-format Ubuntu currently supplied and fed a normal three-line-context diff to `clang-format-diff`. That reformatted untouched neighboring lines. It also used a trailing three-dot diff that ignored local working-tree edits, allowing local checks to pass before the same committed code failed on GitHub.

## Developer impact

Local Docker builds and GitHub now use the same exact formatter and script. Existing untouched source remains the baseline; only changed lines are enforced.

## Validation

- pinned clang-format 14.0.6 config parse: passed
- shellcheck: passed
- controlled tracked-file reject → autofix → pass test: passed
- controlled untracked-header reject → autofix → pass test: passed
- wrong formatter-version rejection: passed
- full project Docker pipeline: passed
  - clang-format 14.0.6
  - cppcheck
  - pytest: 2 passed
  - ARM firmware build: 50,908 bytes

No hardware behavior or firmware source code changes are included.

Closes #41