### PR TITLE
Enforce release tag and artifact integrity

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -41,7 +41,7 @@ jobs:
           sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi
 
       - name: Build firmware
-        run: make -j$(nproc)
+        run: make -j"$(nproc)"
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,7 +32,7 @@ jobs:
           sudo apt-get install -y shellcheck
 
       - name: Ruff (pyflakes)
-        run: python -m ruff check fw-pack.py tests
+        run: python -m ruff check fw-pack.py ci/release_artifacts.py tests
 
       - name: Shellcheck
         run: shellcheck compile-with-docker.sh ci/run.sh ci/check-clang-format.sh
@@ -118,7 +118,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: python -m pip install --upgrade pip pytest crcmod
+        run: python -m pip install --upgrade pip pytest
 
       - name: Run pytest
         run: pytest -q
@@ -135,16 +135,20 @@ jobs:
           submodules: recursive
 
       - name: Derive version suffix
+        env:
+          REQUESTED_SUFFIX: ${{ github.event.inputs.version_suffix }}
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            if [[ -z "${{ github.event.inputs.version_suffix }}" ]]; then
+            if [[ -z "${REQUESTED_SUFFIX}" ]]; then
               echo "VERSION_SUFFIX input is required when running manually" >&2
               exit 1
             fi
-            echo "VERSION_SUFFIX=${{ github.event.inputs.version_suffix }}" >> "$GITHUB_ENV"
+            SUFFIX="${REQUESTED_SUFFIX}"
           else
-            echo "VERSION_SUFFIX=CI${GITHUB_SHA::5}" >> "$GITHUB_ENV"
+            SUFFIX="CI${GITHUB_SHA::5}"
           fi
+          python3 ci/release_artifacts.py validate-suffix "${SUFFIX}"
+          echo "VERSION_SUFFIX=${SUFFIX}" >> "$GITHUB_ENV"
 
       - name: Build firmware (Docker)
         run: ./compile-with-docker.sh
@@ -156,5 +160,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: github.event_name == 'workflow_dispatch'
         with:
-          name: loaner-firmware
-          path: compiled-firmware/loaner-firmware*.bin
+          name: loaner-firmware-${{ github.event.inputs.version_suffix }}
+          path: compiled-firmware/loaner-firmware-*

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -146,6 +146,7 @@ jobs:
             SUFFIX="${REQUESTED_SUFFIX}"
           else
             SUFFIX="CI${GITHUB_SHA::5}"
+            SUFFIX="${SUFFIX^^}"
           fi
           python3 ci/release_artifacts.py validate-suffix "${SUFFIX}"
           echo "VERSION_SUFFIX=${SUFFIX}" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,8 @@ name: Release
 on:
   push:
     tags:
-      - '*'
+      - 'v[0-9][0-9].[0-9][0-9]'
+      - 'v[0-9][0-9].[0-9][0-9].[0-9]*'
 
 permissions:
   contents: write
@@ -19,35 +20,56 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Derive version suffix
+      - name: Validate release tag and firmware suffix
+        id: release
         run: |
-          if [[ ! -f VERSION_SUFFIX ]]; then
-            echo "VERSION_SUFFIX file is missing" >&2
-            exit 1
-          fi
-          SUFFIX="$(tr -d '\r\n' < VERSION_SUFFIX)"
-          if [[ -z "${SUFFIX}" ]]; then
-            echo "VERSION_SUFFIX file is empty" >&2
-            exit 1
-          fi
-          echo "Using VERSION_SUFFIX=${SUFFIX}"
-          echo "VERSION_SUFFIX=${SUFFIX}" >> "$GITHUB_ENV"
+          python3 ci/release_artifacts.py validate-tag \
+            --tag "${GITHUB_REF_NAME}" \
+            --suffix-file VERSION_SUFFIX \
+            --github-output "${GITHUB_OUTPUT}"
 
-      - name: Build firmware (Docker)
+      - name: Refuse to overwrite an existing release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            echo "Release ${GITHUB_REF_NAME} already exists; refusing to overwrite it" >&2
+            exit 1
+          fi
+
+      - name: Build firmware and release bundle
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+          SOURCE_COMMIT: ${{ github.sha }}
+          VERSION_SUFFIX: ${{ steps.release.outputs.version_suffix }}
         run: ./compile-with-docker.sh
+
+      - name: Verify release bundle
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+          VERSION_SUFFIX: ${{ steps.release.outputs.version_suffix }}
+        run: |
+          python3 ci/release_artifacts.py verify-bundle \
+            --manifest "compiled-firmware/loaner-firmware-${VERSION_SUFFIX}.manifest.json" \
+            --expected-suffix "${VERSION_SUFFIX}" \
+            --expected-tag "${RELEASE_TAG}"
 
       - name: List artifacts
         run: ls -l compiled-firmware
 
-      - name: Upload artifacts
+      - name: Upload workflow artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: loaner-firmware
-          path: compiled-firmware/loaner-firmware*.bin
+          name: ${{ steps.release.outputs.artifact_stem }}
+          path: compiled-firmware/loaner-firmware-*
 
-      - name: Create release
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: "compiled-firmware/loaner-firmware*.bin"
-          allowUpdates: true
-          prerelease: false
+      - name: Create immutable GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "${RELEASE_TAG}" \
+            compiled-firmware/loaner-firmware-* \
+            --verify-tag \
+            --title "Loaner firmware ${RELEASE_TAG}" \
+            --generate-notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,10 @@
 - Feature toggles and build-time limits are managed via the `ENABLE_*` blocks at the top of `Makefile`.
 
 ## Build, Test, and Development Commands
-- `make` (or `win_make.bat`) builds `loaner-firmware.bin`; when Python + `crcmod` is available it also emits `loaner-firmware.packed.bin`.
+- `make` (or `win_make.bat`) builds both the raw and required packed firmware; a packing or metadata failure fails the build.
 - `./compile-with-docker.sh` supplies a reproducible GCC 10.3.1 toolchain and writes artifacts to `compiled-firmware/`.
 - `make clean` clears objects before benchmarking size; `make flash`/`make debug` expect OpenOCD with a J-Link config.
-- `python3 fw-pack.py loaner-firmware.bin AUTHOR VERSION loaner-firmware.packed.bin` injects metadata so web flashers accept the build.
+- `python3 fw-pack.py pack loaner-firmware.bin LNR24A5 loaner-firmware.packed.bin` injects metadata; use the `verify` subcommand before publishing an image.
 
 ## Coding Style & Naming Conventions
 - Indent with tabs; macros remain uppercase snake-case (`ENABLE_*`, `SYSCON_*`).
@@ -32,13 +32,13 @@
 ## Branching & Release Workflow
 - Create a feature branch for every change (`git checkout -b feature-name`) and never push commits straight to `main`.
 - Open a pull request targeting `main` once the branch is ready; include build/test notes and hardware validation results.
-- When a milestone lands, tag the merge commit (for example `git tag -a v0.3`) and cut a GitHub release that attaches the packed firmware built from that tag.
+- When a milestone lands, update `VERSION_SUFFIX`, merge it, and tag that exact commit using `vYY.MM[.PATCH]`; the release workflow rejects mismatched tags and existing releases.
 - Keep release notes concise: highlight the loaner-facing changes and link the corresponding ICS-205 or CHIRP updates if applicable.
 
 ## Versioning Strategy
-- Follow the calendar-semver pattern used by other UV-K5 forks (e.g. Quansheng's `v2.1.27` and Open Edition's `OEFW-2023.09`). Adopt `vYY.MM[.PATCH]` for git tags and releases (for example `v24.03` or `v24.03.1` for hotfixes).
+- Use `vYY.MM[.PATCH]` for git tags and releases. Automation maps the tag to the seven-character suffix `LNRYYMP`, using one base-36 digit for month and patch (for example `v24.10.5` maps to `LNR24A5`; an omitted patch maps to `0`). Patches above 35 are rejected.
 - The packed firmware metadata must keep the `*OEFW-` prefix (Quansheng’s bootloader refuses anything else). For CHIRP compatibility we report the stock-style `1.02.<SUFFIX>` string over the UART handshake instead, while the welcome banner continues to show `OEFW-LNR2415`. Update the root `VERSION_SUFFIX` file whenever you change the suffix so CI/release builds stay consistent.
-- Update the tag, the packed image suffix, and the GitHub release name together so end users and CHIRP all report the same version string.
+- Update the root `VERSION_SUFFIX` to the mapped value before tagging. Releases include suffix-bearing raw/packed binaries, a JSON build manifest, and SHA-256 checksums.
 
 ## Firmware Configuration Tips
 - Adjust `ENABLE_*` groups in `Makefile` to keep only the features you can fit, and re-run `make clean` before remeasuring size.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,127 +1,104 @@
 # Building the Loaner Firmware
 
-This document walks through producing firmware binaries locally or inside the provided Docker wrapper. It mirrors the instructions that formerly lived in `README.md`.
+This document covers local builds, validation, firmware packing, and releases.
 
 ## Prerequisites
-- Docker (recommended path; covers the compiler, python tooling, lint, and tests).
-- For native builds only: ARM GCC 10.3.1 toolchain on `PATH`, GNU Make, Python 3 with `crcmod`, plus optional `cppcheck` and `pytest`.
+
+- Docker for the recommended build path.
+- For native builds: ARM GCC 10.3.1 on `PATH`, GNU Make, and Python 3.
+- For native validation: `cppcheck`, `pytest`, and the pinned formatter from `ci/requirements-format.txt`.
 
 ## Docker Build (recommended)
-`./compile-with-docker.sh` produces the most reproducible binaries by packaging the entire toolchain and CI flow inside the container image. The container downloads Arm's official GNU toolchain 10.3-2021.10 (GCC 10.3.1) so firmware bits never depend on whichever cross-compiler Arch happens to ship that week.
 
-1. From the repository root (replace the suffix with your release identifier; see “Versioning” for the naming scheme—suffixes must be exactly 7 alphanumeric characters):
-   ```sh
-   VERSION_SUFFIX=LNR2415 ./compile-with-docker.sh
-   ```
-2. The script builds the Docker image, runs `ci/run.sh` inside the container (cppcheck + pytest + firmware build), and drops artifacts to `compiled-firmware/` on your host:
-   - `compiled-firmware/loaner-firmware.bin`
-   - `compiled-firmware/loaner-firmware.packed.bin`
+Run the complete validation and build pipeline with an exact seven-character uppercase alphanumeric suffix:
 
-If the script fails, inspect the console output; lint or unit test failures abort the build so issues are caught before you publish a release.
-
-## Native Build (optional)
-Docker remains the preferred path. Only follow these steps if you must build locally with an existing toolchain:
-
-1. Clean previous objects:
-   ```sh
-   make clean
-   ```
-2. Build the firmware (the `TARGET` name controls the output filename):
-   ```sh
-   make TARGET=loaner-firmware VERSION_SUFFIX=LNR2415
-   ```
-   The above command produces `loaner-firmware.bin`. If Python with `crcmod` is installed you will also get `loaner-firmware.packed.bin`.  
-   If you omit `TARGET=...` the files are named `firmware.bin` / `firmware.packed.bin`.
-   The build also exports `VERSION_SUFFIX` into the binaries. Set it explicitly (for example `make TARGET=loaner-firmware VERSION_SUFFIX=LNR2415`) or create an `LNR*` git tag that the Makefile can discover. The Makefile uppercases the suffix, strips punctuation, and errors out unless the sanitized value is exactly 7 characters so the radio’s bootloader will accept the banner.
-
-## Creating a Packed Binary Manually
-If the packed image was not produced automatically (for example on a minimal native setup), run:
 ```sh
-python3 fw-pack.py loaner-firmware.bin LNR2415 loaner-firmware.packed.bin
+VERSION_SUFFIX=LNR2415 ./compile-with-docker.sh
 ```
 
-- Replace `LNR2415` with the same 7-character suffix you pass in via `VERSION_SUFFIX`. That value is embedded in both the welcome screen and the packed metadata.  
-  Any punctuation is stripped automatically; if the sanitized value is not exactly 7 characters the build script aborts.
-- The packed image is required for PC loader flashing because it carries the metadata Quansheng's tool expects.
+The wrapper runs the formatting check, cppcheck, pytest, and the ARM build. It writes a verified bundle to `compiled-firmware/`:
 
-## Running Lint and Tests
-- `./compile-with-docker.sh` already executes `ci/run.sh`, so every Docker build runs the changed-line format check, cppcheck, pytest, and the firmware build in one shot.
-- GitHub Actions and the Docker image both install clang-format 14.0.6 from `ci/requirements-format.txt` and invoke `ci/check-clang-format.sh`. The check uses a zero-context diff and formats only C lines changed from `origin/main`; existing untouched source is the controlled baseline.
-- For native development, install the pinned formatter with `python -m pip install -r ci/requirements-format.txt`. Run `ci/check-clang-format.sh` to check your changes or `ci/check-clang-format.sh --fix` to apply the canonical style to changed lines. Pass a different base ref as the final argument when needed, for example `ci/check-clang-format.sh --fix origin/release`.
-- A CHIRP compatibility check clones the driver repo (defaulting to our whitelist branch), asserts that the latest `OEFW-LNR…` banner still passes `k5_approve_firmware`, revalidates that the firmware keeps the OEM channel bounds (MR channels 0–199, etc.), and runs a subset of the UV-K5 driver tests (memory edits/settings mutations). Update `COMPAT_SUFFIX` or the tracked CHIRP ref when cutting new releases so uploads keep working.
-- If you are working natively, `ci/run.sh` reproduces the same flow once the dependencies are installed (see the Dockerfile for the package list). Run it with the same suffix to mirror CI:
-  ```sh
-  VERSION_SUFFIX=LNR2415 ./ci/run.sh
-  ```
-- GitHub Actions runs `pytest` under Python 3.10 and 3.12 before the Docker build; keep tests compatible with both versions.
-- To run individual pieces, consult the script for the exact command switches, then invoke:
-  ```sh
-  cppcheck ...        # optional, mirrors the flags in ci/run.sh
-  pytest              # runs tests/test_fw_pack.py
-  make clean
-  make TARGET=loaner-firmware
-  ```
-- Keep an eye on the binary size reported by `arm-none-eabi-size` at the end of the build when you toggle features.
+- `loaner-firmware-LNR2415.bin`
+- `loaner-firmware-LNR2415.packed.bin`
+- `loaner-firmware-LNR2415.manifest.json`
+- `loaner-firmware-LNR2415.sha256`
+
+The manifest records file sizes and hashes, the source commit, firmware identifiers, and build-tool versions. The checksum file covers both images and the manifest.
+
+## Native Build (optional)
+
+```sh
+make clean
+make TARGET=loaner-firmware VERSION_SUFFIX=LNR2415
+```
+
+This creates `loaner-firmware.bin` and the required `loaner-firmware.packed.bin`. Packing is fail-closed: an invalid suffix, undersized input, packer failure, or missing packed image fails the build. When `VERSION_SUFFIX` is omitted, Make reads the root `VERSION_SUFFIX` file.
+
+## Packing and Verifying an Image
+
+```sh
+python3 fw-pack.py pack loaner-firmware.bin LNR2415 loaner-firmware.packed.bin
+python3 fw-pack.py verify loaner-firmware.packed.bin LNR2415
+```
+
+The verifier checks the XMODEM CRC, `*OEFW-` metadata prefix, exact embedded suffix, and metadata padding. The raw firmware must be at least 8192 bytes so metadata is inserted at the required offset.
+
+## Running Checks
+
+The Docker wrapper is the canonical full check. Native equivalents are:
+
+```sh
+python -m pip install -r ci/requirements-format.txt pytest
+ci/check-clang-format.sh
+CI_MODE=cppcheck ci/run.sh
+pytest -q
+VERSION_SUFFIX=LNR2415 ci/run.sh
+```
+
+GitHub Actions runs tests under Python 3.10 and 3.12, checks CHIRP compatibility, runs CodeQL, and performs the Docker firmware build. Keep the firmware below `MAX_FIRMWARE_SIZE` (122880 bytes by default).
+
+## Release Version Mapping
+
+Release tags must use `vYY.MM[.PATCH]`. They map to the seven-character suffix `LNRYYMP`, where month and patch each use one base-36 digit (`0-9`, then `A-Z`):
+
+| Release tag | Firmware suffix |
+| --- | --- |
+| `v24.03` | `LNR2430` |
+| `v24.10.5` | `LNR24A5` |
+| `v24.12.35` | `LNR24CZ` |
+
+An omitted patch maps to `0`. Months outside 1-12, patches above 35, leading-zero patches, and malformed tags are rejected.
+
+Derive the suffix instead of calculating it manually:
+
+```sh
+python3 ci/release_artifacts.py tag-to-suffix v24.10.5
+```
+
+Before tagging, write the resulting value to the root `VERSION_SUFFIX` file and merge that change. The release workflow requires the file, tag, packed metadata, display banner, UART identifier, artifact names, and manifest to agree.
+
+## Release Checklist
+
+1. Create a release branch from current `main`.
+2. Pick a `vYY.MM[.PATCH]` tag and derive its suffix.
+3. Update `VERSION_SUFFIX`, build with that suffix, and run all checks.
+4. Flash the packed image and confirm the displayed version on hardware.
+5. Merge the release preparation PR.
+6. Tag the exact merge commit and push the annotated tag:
+
+   ```sh
+   git tag -a v24.10.5 -m "Loaner firmware v24.10.5"
+   git push origin v24.10.5
+   ```
+
+7. Confirm the automated release contains the raw image, packed image, JSON manifest, and SHA-256 file.
+
+The release workflow only triggers for version-shaped tags, validates the full tag syntax, rebuilds the tagged commit, verifies the bundle before upload, and refuses to overwrite an existing GitHub release.
 
 ## Feature Toggles
-Feature flags live near the top of `Makefile` as `ENABLE_*` macros. The loaner build keeps the optional blocks (`AIRCOPY`, `ALARM`, `FMRADIO`, `NOAA`, `TX1750`, and the SRAM overlay) disabled by default to shrink the binary and hide extra menus. Adjust the macros if you need those features, then run `make clean` before comparing binary size after any toggle changes.
+
+Feature flags live near the top of `Makefile`. The loaner build keeps AIRCOPY, ALARM, FM radio, NOAA, TX1750, and the SRAM overlay disabled by default. Run `make clean` before comparing size after changing flags.
 
 ## Transmit Policy
-The loaner build does not enforce the legacy regional `F LOCK` presets or the `200TX`, `350TX`, `350EN`, and `500TX` EEPROM switches. Those fields remain in the EEPROM layout for CHIRP compatibility, but runtime transmit validation only checks that a programmed transmit frequency falls inside one of the firmware's defined tuning bands: 50–76 MHz or 108–600 MHz. The unsupported 76–108 MHz gap, out-of-range frequencies, and non-transmittable special channel types remain blocked.
 
-## Firmware Metadata and Releases
-- A successful build leaves you with `firmware.bin` (raw) and, when Python and `crcmod` are available, `firmware.packed.bin`. The packed image is what Quansheng's loader validates.
-- Use `fw-pack.py` to stamp a release tag into the packed image. `make` already invokes the script with `VERSION_SUFFIX`, so the packed file inherits the same banner. To repack manually, pass the suffix yourself (example above).
-- When building outside of Docker, set `VERSION_SUFFIX` in your environment once (for example `export VERSION_SUFFIX=LNR2415`) so every command picks up the same value.  
-  For Docker builds, prefix the wrapper with the same variable:  
-  ```sh
-  VERSION_SUFFIX=LNR2415 ./compile-with-docker.sh
-  ```
-- Change the `TARGET` on the `make` command line to tweak the output filenames without editing source, for example `make TARGET=loaner-firmware`.
-- Before publishing a release, spot-check the welcome screen on hardware to make sure the tag matches what you intend to share with end users.
-- Recommended version format: mirror other UV-K5 firmware projects (Quansheng's stock firmware ships as `v2.1.27`, Open Edition uses `OEFW-2023.09`). Tag milestones as `vYY.MM[.PATCH]` but feed the firmware a 7-character, punctuation-free `VERSION_SUFFIX` (for example suffix `LNR2415` for release `v24.12.4`). The packed metadata must remain `*OEFW-LNR2415` so the bootloader accepts the image, while the UART handshake tells CHIRP the stock-style `1.02.LNR2415` string for compatibility.
-
-## Release Versioning Checklist
-Follow this sequence for every tagged release:
-
-0. **Create a release branch**: Start from `main` and branch before making release edits (for example `git checkout -b release/LNR24.12`). All commits should land via a merge request.
-1. **Pick a suffix**: Choose an exactly 7-character identifier in the form `LNRYYNN` or `LNRYYNP` (for example `LNR2415`) and update the root `VERSION_SUFFIX` file so automation can read it. The suffix should line up with the git tag you plan to publish (for example `v24.12.4`) without introducing punctuation that the bootloader rejects.
-2. **Export the suffix** so every build step sees the same value:
-   ```sh
-   export VERSION_SUFFIX=LNR2415
-   ```
-   (Or prefix individual commands with `VERSION_SUFFIX=...` if you prefer.)
-3. **Build and test** (Docker path preferred):
-   ```sh
-   VERSION_SUFFIX=LNR2415 ./compile-with-docker.sh
-   ```
-   This reproduces the CI pipeline (cppcheck + pytest + firmware build) and drops sanitized artifacts such as `compiled-firmware/loaner-firmware-LNR2415.bin/.packed.bin`.  
-   If you must build natively, run:
-   ```sh
-   make clean
-   make TARGET=loaner-firmware VERSION_SUFFIX=LNR2415
-   pytest -q
-   ```
-   Either path should pass without warnings; capture the output for the merge request description. Confirm the printed firmware size stays below the configured limit (`MAX_FIRMWARE_SIZE`, default 122 880 bytes) so there is margin for future changes.
-4. **Validate on hardware**: Flash the packed image and confirm the radio splash reports the sanitized banner (for example `OEFW-LNR2415`).
-5. **Tag the release** using the calendar semantic scheme:
-   ```sh
-  git tag -a v24.12.4 -m "Loaner firmware v24.12.4"
-  git push origin v24.12.4
-   ```
-6. **Publish the GitHub release**: Attach the packed binary (`compiled-firmware/loaner-firmware-LNR2415.packed.bin`) and include the validation steps in the notes. If you prefer CI-generated artifacts, trigger the `CI` workflow manually via “Run workflow” in GitHub and supply `LNR2415` as the `version_suffix`; the workflow only uploads artifacts on manual runs.
-7. **Upstream tooling**: If you ever change the metadata prefix (`*OEFW-`), the UART handshake string (`1.02.`), or the on-radio banner (`OEFW-`), update dependent projects (for example Egzumer’s CHIRP driver) so they continue to recognise the build. As long as the suffix stays alphanumeric, CHIRP treats the `1.02.<SUFFIX>` handshake like the stock firmware string.
-
-## Branching and Release Flow
-1. Start work on a fresh branch instead of `main`:
-   ```sh
-   git checkout -b feature-name
-   ```
-2. Build and test (preferably with `./compile-with-docker.sh`), document the validation steps, then open a pull request back to `main`.
-3. Once the branch merges, create an annotated tag for the milestone:
-   ```sh
-   git tag -a v0.3 -m "Loaner v0.3"
-   git push origin v0.3
-   ```
-4. Draft a GitHub release from that tag and attach the packed firmware produced from the same commit (for example `compiled-firmware/loaner-firmware.packed.bin`).
-5. Repeat the process for each milestone so end users always have a tagged firmware matching the published release notes.
+The loaner build does not enforce the legacy regional `F LOCK`, `200TX`, `350TX`, `350EN`, or `500TX` policy switches. It still blocks the unsupported 76-108 MHz gap, frequencies outside the defined 50-76 MHz and 108-600 MHz tuning bands, and non-transmittable special channels.

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN pacman -Syyu --noconfirm \
     base-devel \
     git \
     python-pip \
-    python-crcmod \
     python-pytest \
     cppcheck \
     ca-certificates \

--- a/Makefile
+++ b/Makefile
@@ -114,19 +114,20 @@ CC = arm-none-eabi-gcc
 LD = arm-none-eabi-gcc
 OBJCOPY = arm-none-eabi-objcopy
 SIZE = arm-none-eabi-size
+PYTHON ?= python3
 
 GIT_HASH := $(shell git rev-parse --short HEAD)
 
-VERSION_SUFFIX ?= $(shell git describe --tags --match 'LNR*' --abbrev=0 2>/dev/null)
+VERSION_SUFFIX ?= $(strip $(shell cat VERSION_SUFFIX 2>/dev/null))
 
 ifeq ($(MAKECMDGOALS),)
   ifeq ($(strip $(VERSION_SUFFIX)),)
-    $(error VERSION_SUFFIX is required. Set VERSION_SUFFIX=LNR24A5 or create an LNR* tag.)
+    $(error VERSION_SUFFIX is required. Set VERSION_SUFFIX=LNR24A5 or update the root VERSION_SUFFIX file.)
   endif
 else
   ifneq ($(filter-out clean,$(MAKECMDGOALS)),)
     ifeq ($(strip $(VERSION_SUFFIX)),)
-      $(error VERSION_SUFFIX is required. Set VERSION_SUFFIX=LNR24A5 or create an LNR* tag.)
+      $(error VERSION_SUFFIX is required. Set VERSION_SUFFIX=LNR24A5 or update the root VERSION_SUFFIX file.)
     endif
 endif
 endif
@@ -145,7 +146,7 @@ ifneq ($(VERSION_SUFFIX_LEN),7)
 endif
 
 ifneq ($(VERSION_SUFFIX),$(VERSION_SUFFIX_RAW))
-  $(warning VERSION_SUFFIX sanitized from "$(VERSION_SUFFIX_RAW)" to "$(VERSION_SUFFIX)")
+  $(error VERSION_SUFFIX "$(VERSION_SUFFIX_RAW)" must contain only uppercase ASCII letters and digits)
 endif
 
 VERSION_SUFFIX_ESCAPED := $(subst ",\",$(VERSION_SUFFIX))
@@ -201,8 +202,8 @@ DEPS = $(OBJS:.o=.d)
 
 all: $(TARGET)
 	$(OBJCOPY) -O binary $< $<.bin
-	-python fw-pack.py $<.bin $(VERSION_SUFFIX) $<.packed.bin
-	-python3 fw-pack.py $<.bin $(VERSION_SUFFIX) $<.packed.bin
+	$(PYTHON) fw-pack.py pack $<.bin $(VERSION_SUFFIX) $<.packed.bin
+	test -s $<.packed.bin
 	$(SIZE) $<
 
 debug:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The project also gives COML/COMT staff a predictable path from the ICS-205 form 
 > Flashing third-party firmware is always at your own risk. Test on non-critical hardware first and confirm RF behaviour before handing units out.
 
 ## Quickstart
-1. Download the latest packed release (`loaner-firmware.packed.bin`) from the Releases page.
+1. Download the latest suffix-bearing packed release (for example `loaner-firmware-LNR24A5.packed.bin`) from the Releases page and, when practical, compare it with the published SHA-256 file.
 2. With the radio powered off, hold the **PTT** and the **top side key** while turning it on. The display should stay blank, indicating the bootloader is active.
 3. Connect the USB cable, open Quansheng's PC programming tool, select *Firmware Update*, point it at the packed image, and start the transfer.
 4. After the loader reports success, power the radio off and back on to confirm the welcome screen shows the release tag from the packed image.

--- a/ci/release_artifacts.py
+++ b/ci/release_artifacts.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+PACKER_PATH = REPOSITORY_ROOT / "fw-pack.py"
+TAG_PATTERN = re.compile(
+	r"^v(?P<year>[0-9]{2})\.(?P<month>0[1-9]|1[0-2])(?:\.(?P<patch>0|[1-9][0-9]?))?$"
+)
+SUFFIX_PATTERN = re.compile(r"^[A-Z0-9]{7}$")
+BASE36 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+MANIFEST_SCHEMA = 1
+
+
+class ReleaseError(ValueError):
+	pass
+
+
+def _load_packer():
+	spec = importlib.util.spec_from_file_location("firmware_packer", PACKER_PATH)
+	if spec is None or spec.loader is None:
+		raise RuntimeError(f"unable to load firmware packer from {PACKER_PATH}")
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+def validate_suffix(suffix: str) -> str:
+	if not SUFFIX_PATTERN.fullmatch(suffix):
+		raise ReleaseError("VERSION_SUFFIX must be exactly 7 uppercase alphanumeric characters")
+	return suffix
+
+
+def tag_to_suffix(tag: str) -> str:
+	match = TAG_PATTERN.fullmatch(tag)
+	if match is None:
+		raise ReleaseError("release tag must match vYY.MM or vYY.MM.PATCH")
+
+	month = int(match.group("month"))
+	patch = int(match.group("patch") or "0")
+	if patch >= len(BASE36):
+		raise ReleaseError("release patch must be between 0 and 35")
+	return f"LNR{match.group('year')}{BASE36[month]}{BASE36[patch]}"
+
+
+def file_sha256(path: Path) -> str:
+	digest = hashlib.sha256()
+	with path.open("rb") as handle:
+		for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+			digest.update(chunk)
+	return digest.hexdigest()
+
+
+def first_version_line(command: list[str]) -> str:
+	try:
+		result = subprocess.run(command, check=True, capture_output=True, text=True)
+	except (OSError, subprocess.CalledProcessError):
+		return "unavailable"
+	output = result.stdout or result.stderr
+	return output.splitlines()[0].strip() if output else "unavailable"
+
+
+def validate_tag(tag: str, suffix_file: Path) -> str:
+	expected = tag_to_suffix(tag)
+	try:
+		actual = suffix_file.read_text(encoding="ascii").strip()
+	except OSError as error:
+		raise ReleaseError(f"unable to read suffix file {suffix_file}: {error}") from error
+	validate_suffix(actual)
+	if actual != expected:
+		raise ReleaseError(
+			f"VERSION_SUFFIX mismatch for {tag}: expected {expected}, found {actual}"
+		)
+	return actual
+
+
+def bundle_artifacts(
+	*,
+	suffix: str,
+	raw_path: Path,
+	packed_path: Path,
+	output_dir: Path,
+	source_commit: str,
+	release_tag: str | None,
+) -> Path:
+	validate_suffix(suffix)
+	if not re.fullmatch(r"[0-9a-f]{40}", source_commit):
+		raise ReleaseError("source commit must be a full 40-character lowercase SHA")
+	if release_tag is not None and tag_to_suffix(release_tag) != suffix:
+		raise ReleaseError(f"release tag {release_tag} does not map to suffix {suffix}")
+
+	packer = _load_packer()
+	raw_firmware = raw_path.read_bytes()
+	packed_firmware = packed_path.read_bytes()
+	packed_suffix = packer.inspect_firmware(packed_firmware)
+	if packed_suffix != suffix:
+		raise ReleaseError(
+			f"packed firmware suffix mismatch: expected {suffix}, got {packed_suffix}"
+		)
+	if packer.pack_firmware(raw_firmware, suffix) != packed_firmware:
+		raise ReleaseError("packed firmware does not match the raw firmware image")
+
+	output_dir.mkdir(parents=True, exist_ok=True)
+	stem = f"loaner-firmware-{suffix}"
+	raw_output = output_dir / f"{stem}.bin"
+	packed_output = output_dir / f"{stem}.packed.bin"
+	manifest_path = output_dir / f"{stem}.manifest.json"
+	checksums_path = output_dir / f"{stem}.sha256"
+	shutil.copyfile(raw_path, raw_output)
+	shutil.copyfile(packed_path, packed_output)
+
+	files = {}
+	for path, kind in ((raw_output, "raw"), (packed_output, "packed")):
+		files[path.name] = {
+			"kind": kind,
+			"sha256": file_sha256(path),
+			"size": path.stat().st_size,
+		}
+
+	manifest = {
+		"schema": MANIFEST_SCHEMA,
+		"release_tag": release_tag,
+		"source_commit": source_commit,
+		"version_suffix": suffix,
+		"firmware_ids": {
+			"display_banner": f"OEFW-{suffix}",
+			"packed_metadata": f"*OEFW-{suffix}",
+			"uart_handshake": f"1.02.{suffix}",
+		},
+		"files": files,
+		"tools": {
+			"arm_gcc": first_version_line(["arm-none-eabi-gcc", "--version"]),
+			"arm_ld": first_version_line(["arm-none-eabi-ld", "--version"]),
+			"python": platform.python_version(),
+			"packer": "fw-pack.py schema 1",
+		},
+	}
+	manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+	checksum_paths = (raw_output, packed_output, manifest_path)
+	checksums_path.write_text(
+		"".join(f"{file_sha256(path)}  {path.name}\n" for path in checksum_paths),
+		encoding="ascii",
+	)
+	return manifest_path
+
+
+def verify_bundle(manifest_path: Path, expected_suffix: str, expected_tag: str | None) -> None:
+	validate_suffix(expected_suffix)
+	try:
+		manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+	except (OSError, json.JSONDecodeError) as error:
+		raise ReleaseError(f"unable to read manifest {manifest_path}: {error}") from error
+
+	if manifest.get("schema") != MANIFEST_SCHEMA:
+		raise ReleaseError("unsupported release manifest schema")
+	if manifest.get("version_suffix") != expected_suffix:
+		raise ReleaseError("release manifest suffix does not match the expected suffix")
+	if manifest.get("release_tag") != expected_tag:
+		raise ReleaseError("release manifest tag does not match the expected tag")
+	if expected_tag is not None and tag_to_suffix(expected_tag) != expected_suffix:
+		raise ReleaseError("expected release tag and suffix do not match")
+
+	for filename, metadata in manifest.get("files", {}).items():
+		path = manifest_path.parent / filename
+		if not path.is_file():
+			raise ReleaseError(f"release artifact is missing: {filename}")
+		if path.stat().st_size != metadata.get("size"):
+			raise ReleaseError(f"release artifact size mismatch: {filename}")
+		if file_sha256(path) != metadata.get("sha256"):
+			raise ReleaseError(f"release artifact checksum mismatch: {filename}")
+		if metadata.get("kind") == "packed":
+			packer = _load_packer()
+			if packer.inspect_firmware(path.read_bytes()) != expected_suffix:
+				raise ReleaseError(f"release artifact metadata mismatch: {filename}")
+
+	checksums_path = manifest_path.with_suffix("").with_suffix(".sha256")
+	if not checksums_path.is_file():
+		raise ReleaseError(f"release checksum file is missing: {checksums_path.name}")
+	checksum_paths = [manifest_path.parent / name for name in manifest["files"]]
+	checksum_paths.append(manifest_path)
+	expected_checksums = "".join(
+		f"{file_sha256(path)}  {path.name}\n" for path in checksum_paths
+	)
+	if checksums_path.read_text(encoding="ascii") != expected_checksums:
+		raise ReleaseError("release checksum file does not match the bundle")
+
+
+def build_parser() -> argparse.ArgumentParser:
+	parser = argparse.ArgumentParser(description="Validate release versions and firmware artifacts")
+	subparsers = parser.add_subparsers(dest="command", required=True)
+
+	suffix_parser = subparsers.add_parser("validate-suffix")
+	suffix_parser.add_argument("suffix")
+
+	tag_parser = subparsers.add_parser("tag-to-suffix")
+	tag_parser.add_argument("tag")
+
+	validate_parser = subparsers.add_parser("validate-tag")
+	validate_parser.add_argument("--tag", required=True)
+	validate_parser.add_argument("--suffix-file", required=True, type=Path)
+	validate_parser.add_argument("--github-output", type=Path)
+
+	bundle_parser = subparsers.add_parser("bundle")
+	bundle_parser.add_argument("--suffix", required=True)
+	bundle_parser.add_argument("--raw", required=True, type=Path)
+	bundle_parser.add_argument("--packed", required=True, type=Path)
+	bundle_parser.add_argument("--output-dir", required=True, type=Path)
+	bundle_parser.add_argument("--source-commit", required=True)
+	bundle_parser.add_argument("--tag")
+
+	verify_parser = subparsers.add_parser("verify-bundle")
+	verify_parser.add_argument("--manifest", required=True, type=Path)
+	verify_parser.add_argument("--expected-suffix", required=True)
+	verify_parser.add_argument("--expected-tag")
+	return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+	args = build_parser().parse_args(argv)
+	try:
+		if args.command == "validate-suffix":
+			print(validate_suffix(args.suffix))
+		elif args.command == "tag-to-suffix":
+			print(tag_to_suffix(args.tag))
+		elif args.command == "validate-tag":
+			suffix = validate_tag(args.tag, args.suffix_file)
+			print(suffix)
+			if args.github_output is not None:
+				with args.github_output.open("a", encoding="utf-8") as output:
+					output.write(f"version_suffix={suffix}\n")
+					output.write(f"artifact_stem=loaner-firmware-{suffix}\n")
+		elif args.command == "bundle":
+			manifest = bundle_artifacts(
+				suffix=args.suffix,
+				raw_path=args.raw,
+				packed_path=args.packed,
+				output_dir=args.output_dir,
+				source_commit=args.source_commit,
+				release_tag=args.tag,
+			)
+			print(manifest)
+		else:
+			verify_bundle(args.manifest, args.expected_suffix, args.expected_tag)
+			print(f"verified {args.manifest}")
+		return 0
+	except (ReleaseError, OSError, ValueError) as error:
+		print(f"release-artifacts: {error}", file=sys.stderr)
+		return 1
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -52,7 +52,10 @@ fi
 : "${VERSION_SUFFIX:?VERSION_SUFFIX is required (set a 7-character value such as VERSION_SUFFIX=LNR2415 before running this script)}"
 
 mkdir -p "${ARTIFACT_DIR}"
-rm -f "${ARTIFACT_DIR}"/loaner-firmware*.bin
+rm -f \
+	"${ARTIFACT_DIR}"/loaner-firmware-* \
+	"${ARTIFACT_DIR}/loaner-firmware.bin" \
+	"${ARTIFACT_DIR}/loaner-firmware.packed.bin"
 
 echo "Checking C formatting..."
 "${ROOT}/ci/check-clang-format.sh"
@@ -64,7 +67,7 @@ pytest -q
 
 echo "Building firmware..."
 make clean
-make TARGET=loaner-firmware
+make TARGET=loaner-firmware VERSION_SUFFIX="${VERSION_SUFFIX}"
 
 BIN_SIZE=$(stat --format="%s" loaner-firmware.bin)
 MAX_SIZE=${MAX_FIRMWARE_SIZE:-122880}
@@ -75,4 +78,23 @@ fi
 
 echo "Firmware size: ${BIN_SIZE} bytes (limit ${MAX_SIZE})"
 
-cp loaner-firmware*.bin "${ARTIFACT_DIR}/"
+SOURCE_COMMIT="${SOURCE_COMMIT:-$(git rev-parse HEAD)}"
+BUNDLE_ARGS=(
+	--suffix "${VERSION_SUFFIX}"
+	--source-commit "${SOURCE_COMMIT}"
+	--raw loaner-firmware.bin
+	--packed loaner-firmware.packed.bin
+	--output-dir "${ARTIFACT_DIR}"
+)
+VERIFY_ARGS=(
+	--manifest "${ARTIFACT_DIR}/loaner-firmware-${VERSION_SUFFIX}.manifest.json"
+	--expected-suffix "${VERSION_SUFFIX}"
+)
+if [[ -n "${RELEASE_TAG:-}" ]]; then
+	BUNDLE_ARGS+=(--tag "${RELEASE_TAG}")
+	VERIFY_ARGS+=(--expected-tag "${RELEASE_TAG}")
+fi
+
+echo "Creating verified artifact bundle..."
+python3 ci/release_artifacts.py bundle "${BUNDLE_ARGS[@]}"
+python3 ci/release_artifacts.py verify-bundle "${VERIFY_ARGS[@]}"

--- a/compile-with-docker.sh
+++ b/compile-with-docker.sh
@@ -9,15 +9,27 @@ if [[ -z "${VERSION_SUFFIX:-}" ]]; then
   echo "VERSION_SUFFIX must be set (use a 7-character alphanumeric value, e.g. VERSION_SUFFIX=LNR2415 ./compile-with-docker.sh)" >&2
   exit 1
 fi
+if [[ ! "${VERSION_SUFFIX}" =~ ^[A-Z0-9]{7}$ ]]; then
+  echo "VERSION_SUFFIX must be exactly 7 uppercase alphanumeric characters" >&2
+  exit 1
+fi
+
+SOURCE_COMMIT="${SOURCE_COMMIT:-$(git -C "${SCRIPT_DIR}" rev-parse HEAD)}"
+RELEASE_TAG="${RELEASE_TAG:-}"
 
 mkdir -p "${OUT_DIR}"
 
-rm -f "${OUT_DIR}"/loaner-firmware*.bin
+rm -f \
+  "${OUT_DIR}"/loaner-firmware-* \
+  "${OUT_DIR}/loaner-firmware.bin" \
+  "${OUT_DIR}/loaner-firmware.packed.bin"
 
 docker build -t "${IMAGE_TAG}" "${SCRIPT_DIR}"
 
 docker run --rm \
   -v "${OUT_DIR}":/app/compiled-firmware \
   -e VERSION_SUFFIX="${VERSION_SUFFIX}" \
+  -e SOURCE_COMMIT="${SOURCE_COMMIT}" \
+  -e RELEASE_TAG="${RELEASE_TAG}" \
   "${IMAGE_TAG}" \
   /bin/bash -lc "cd /app && chmod +x ci/run.sh && ./ci/run.sh"

--- a/fw-pack.py
+++ b/fw-pack.py
@@ -1,40 +1,148 @@
 #!/usr/bin/env python3
 
-import crcmod
+import argparse
+import re
 import sys
-
+from binascii import crc_hqx
 from itertools import cycle
+from pathlib import Path
+
 
 OBFUSCATION = [
-        0x47, 0x22, 0xC0, 0x52, 0x5D, 0x57, 0x48, 0x94, 0xB1, 0x60, 0x60, 0xDB, 0x6F, 0xE3, 0x4C, 0x7C,
-        0xD8, 0x4A, 0xD6, 0x8B, 0x30, 0xEC, 0x25, 0xE0, 0x4C, 0xD9, 0x00, 0x7F, 0xBF, 0xE3, 0x54, 0x05,
-        0xE9, 0x3A, 0x97, 0x6B, 0xB0, 0x6E, 0x0C, 0xFB, 0xB1, 0x1A, 0xE2, 0xC9, 0xC1, 0x56, 0x47, 0xE9,
-        0xBA, 0xF1, 0x42, 0xB6, 0x67, 0x5F, 0x0F, 0x96, 0xF7, 0xC9, 0x3C, 0x84, 0x1B, 0x26, 0xE1, 0x4E,
-        0x3B, 0x6F, 0x66, 0xE6, 0xA0, 0x6A, 0xB0, 0xBF, 0xC6, 0xA5, 0x70, 0x3A, 0xBA, 0x18, 0x9E, 0x27,
-        0x1A, 0x53, 0x5B, 0x71, 0xB1, 0x94, 0x1E, 0x18, 0xF2, 0xD6, 0x81, 0x02, 0x22, 0xFD, 0x5A, 0x28,
-        0x91, 0xDB, 0xBA, 0x5D, 0x64, 0xC6, 0xFE, 0x86, 0x83, 0x9C, 0x50, 0x1C, 0x73, 0x03, 0x11, 0xD6,
-        0xAF, 0x30, 0xF4, 0x2C, 0x77, 0xB2, 0x7D, 0xBB, 0x3F, 0x29, 0x28, 0x57, 0x22, 0xD6, 0x92, 0x8B,
-    ]
+	0x47, 0x22, 0xC0, 0x52, 0x5D, 0x57, 0x48, 0x94, 0xB1, 0x60, 0x60, 0xDB, 0x6F, 0xE3, 0x4C, 0x7C,
+	0xD8, 0x4A, 0xD6, 0x8B, 0x30, 0xEC, 0x25, 0xE0, 0x4C, 0xD9, 0x00, 0x7F, 0xBF, 0xE3, 0x54, 0x05,
+	0xE9, 0x3A, 0x97, 0x6B, 0xB0, 0x6E, 0x0C, 0xFB, 0xB1, 0x1A, 0xE2, 0xC9, 0xC1, 0x56, 0x47, 0xE9,
+	0xBA, 0xF1, 0x42, 0xB6, 0x67, 0x5F, 0x0F, 0x96, 0xF7, 0xC9, 0x3C, 0x84, 0x1B, 0x26, 0xE1, 0x4E,
+	0x3B, 0x6F, 0x66, 0xE6, 0xA0, 0x6A, 0xB0, 0xBF, 0xC6, 0xA5, 0x70, 0x3A, 0xBA, 0x18, 0x9E, 0x27,
+	0x1A, 0x53, 0x5B, 0x71, 0xB1, 0x94, 0x1E, 0x18, 0xF2, 0xD6, 0x81, 0x02, 0x22, 0xFD, 0x5A, 0x28,
+	0x91, 0xDB, 0xBA, 0x5D, 0x64, 0xC6, 0xFE, 0x86, 0x83, 0x9C, 0x50, 0x1C, 0x73, 0x03, 0x11, 0xD6,
+	0xAF, 0x30, 0xF4, 0x2C, 0x77, 0xB2, 0x7D, 0xBB, 0x3F, 0x29, 0x28, 0x57, 0x22, 0xD6, 0x92, 0x8B,
+]
 
-def obfuscate(fw):
-    return bytes([a^b for a, b in zip(fw, cycle(OBFUSCATION))])
+METADATA_OFFSET = 0x2000
+METADATA_PREFIX = b"*OEFW-"
+METADATA_SIZE = 16
+SUFFIX_PATTERN = re.compile(r"^[A-Z0-9]{7}$")
 
-METADATA_PREFIX = b'*OEFW-'
 
-plain = open(sys.argv[1], 'rb').read()
-if len(sys.argv[2]) > 10:
-    print('Version suffix is too big!')
-    sys.exit(1)
+class FirmwarePackError(ValueError):
+	pass
 
-version = METADATA_PREFIX + bytes(sys.argv[2], 'ascii')
-if len(version) < 16:
-    version += b'\x00' * (16 - len(version))
 
-packed = obfuscate(plain[:0x2000] + version + plain[0x2000:])
+def obfuscate(firmware: bytes) -> bytes:
+	return bytes(a ^ b for a, b in zip(firmware, cycle(OBFUSCATION)))
 
-crc = crcmod.predefined.Crc('xmodem')
-crc.update(packed)
-digest = crc.digest()
-digest = bytes([digest[1], digest[0]])
 
-open(sys.argv[3], 'wb').write(packed + digest)
+def validate_suffix(suffix: str) -> str:
+	if not SUFFIX_PATTERN.fullmatch(suffix):
+		raise FirmwarePackError("version suffix must be exactly 7 uppercase alphanumeric characters")
+	return suffix
+
+
+def version_block(suffix: str) -> bytes:
+	validate_suffix(suffix)
+	block = METADATA_PREFIX + suffix.encode("ascii")
+	return block + (b"\x00" * (METADATA_SIZE - len(block)))
+
+
+def crc_bytes(payload: bytes) -> bytes:
+	crc = crc_hqx(payload, 0x0000)
+	return bytes([crc & 0xFF, (crc >> 8) & 0xFF])
+
+
+def pack_firmware(plain: bytes, suffix: str) -> bytes:
+	if len(plain) < METADATA_OFFSET:
+		raise FirmwarePackError(
+			f"input firmware is too small: need at least {METADATA_OFFSET} bytes, got {len(plain)}"
+		)
+
+	clear = plain[:METADATA_OFFSET] + version_block(suffix) + plain[METADATA_OFFSET:]
+	payload = obfuscate(clear)
+	return payload + crc_bytes(payload)
+
+
+def inspect_firmware(packed: bytes) -> str:
+	minimum_size = METADATA_OFFSET + METADATA_SIZE + 2
+	if len(packed) < minimum_size:
+		raise FirmwarePackError(
+			f"packed firmware is too small: need at least {minimum_size} bytes, got {len(packed)}"
+		)
+
+	payload, stored_crc = packed[:-2], packed[-2:]
+	expected_crc = crc_bytes(payload)
+	if stored_crc != expected_crc:
+		raise FirmwarePackError(
+			f"packed firmware CRC mismatch: expected {expected_crc.hex()}, got {stored_crc.hex()}"
+		)
+
+	clear = obfuscate(payload)
+	block = clear[METADATA_OFFSET : METADATA_OFFSET + METADATA_SIZE]
+	if not block.startswith(METADATA_PREFIX):
+		raise FirmwarePackError("packed firmware metadata prefix is missing")
+
+	suffix_bytes = block[len(METADATA_PREFIX) : len(METADATA_PREFIX) + 7]
+	try:
+		suffix = suffix_bytes.decode("ascii")
+	except UnicodeDecodeError as error:
+		raise FirmwarePackError("packed firmware suffix is not ASCII") from error
+	validate_suffix(suffix)
+
+	padding = block[len(METADATA_PREFIX) + 7 :]
+	if padding != b"\x00" * len(padding):
+		raise FirmwarePackError("packed firmware metadata padding is invalid")
+	return suffix
+
+
+def write_packed(input_path: Path, suffix: str, output_path: Path) -> None:
+	if input_path.resolve() == output_path.resolve():
+		raise FirmwarePackError("input and output paths must be different")
+	temporary_path = output_path.with_name(f".{output_path.name}.tmp")
+	try:
+		packed = pack_firmware(input_path.read_bytes(), suffix)
+		temporary_path.write_bytes(packed)
+		temporary_path.replace(output_path)
+	except Exception:
+		if output_path.exists():
+			output_path.unlink()
+		raise
+	finally:
+		if temporary_path.exists():
+			temporary_path.unlink()
+
+
+def build_parser() -> argparse.ArgumentParser:
+	parser = argparse.ArgumentParser(description="Pack and verify UV-K5 firmware images")
+	subparsers = parser.add_subparsers(dest="command", required=True)
+
+	pack_parser = subparsers.add_parser("pack", help="insert metadata and pack a raw firmware image")
+	pack_parser.add_argument("input", type=Path)
+	pack_parser.add_argument("suffix")
+	pack_parser.add_argument("output", type=Path)
+
+	verify_parser = subparsers.add_parser("verify", help="verify CRC and embedded metadata")
+	verify_parser.add_argument("input", type=Path)
+	verify_parser.add_argument("suffix", nargs="?")
+	return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+	args = build_parser().parse_args(argv)
+	try:
+		if args.command == "pack":
+			write_packed(args.input, args.suffix, args.output)
+			return 0
+
+		suffix = inspect_firmware(args.input.read_bytes())
+		if args.suffix is not None and suffix != validate_suffix(args.suffix):
+			raise FirmwarePackError(
+				f"packed firmware suffix mismatch: expected {args.suffix}, got {suffix}"
+			)
+		print(suffix)
+		return 0
+	except (FirmwarePackError, OSError) as error:
+		print(f"fw-pack: {error}", file=sys.stderr)
+		return 1
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/tests/test_fw_pack.py
+++ b/tests/test_fw_pack.py
@@ -1,75 +1,108 @@
-import ast
+import importlib.util
 import subprocess
 import sys
-from binascii import crc_hqx
-from itertools import cycle
 from pathlib import Path
 
-
-def _load_obfuscation():
-    tree = ast.parse(Path("fw-pack.py").read_text())
-    for node in tree.body:
-        if isinstance(node, ast.Assign):
-            target = node.targets[0]
-            if isinstance(target, ast.Name) and target.id == "OBFUSCATION":
-                values = []
-                for elt in node.value.elts:
-                    if isinstance(elt, ast.Constant):
-                        values.append(elt.value)
-                    else:
-                        raise ValueError("Unexpected AST element in OBFUSCATION table")
-                return values
-    raise RuntimeError("OBFUSCATION table not found")
+import pytest
 
 
-OBFUSCATION = _load_obfuscation()
+def _load_packer():
+	spec = importlib.util.spec_from_file_location("firmware_packer", Path("fw-pack.py"))
+	assert spec is not None
+	assert spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
 
 
-def deobfuscate(payload: bytes) -> bytes:
-    return bytes(a ^ b for a, b in zip(payload, cycle(OBFUSCATION)))
+PACKER = _load_packer()
 
 
-def run_fw_pack(input_path, version, output_path):
-    subprocess.run(
-        [sys.executable, "fw-pack.py", str(input_path), version, str(output_path)],
-        check=True,
-    )
+def run_fw_pack(*args, check=True):
+	return subprocess.run(
+		[sys.executable, "fw-pack.py", *map(str, args)],
+		check=check,
+		capture_output=True,
+		text=True,
+	)
 
 
-def test_fw_pack_injects_version(tmp_path):
-    plain = (b"\x01\x02\x03\x04" * 4096)  # 16 KiB test payload
-    input_bin = tmp_path / "input.bin"
-    packed_bin = tmp_path / "output.bin"
-    input_bin.write_bytes(plain)
+def test_fw_pack_injects_version_and_verifies_image(tmp_path):
+	plain = b"\x01\x02\x03\x04" * 4096
+	input_bin = tmp_path / "input.bin"
+	packed_bin = tmp_path / "output.bin"
+	input_bin.write_bytes(plain)
 
-    run_fw_pack(input_bin, "LOANER01", packed_bin)
+	run_fw_pack("pack", input_bin, "LOANR01", packed_bin)
+	result = run_fw_pack("verify", packed_bin, "LOANR01")
 
-    data = packed_bin.read_bytes()
-    assert len(data) == len(plain) + 16 + 2  # Version block inserted + CRC
-
-    deobfuscated = deobfuscate(data[:-2])
-    version_block = deobfuscated[0x2000:0x2010]
-    assert version_block.startswith(b"*OEFW-")
-    assert version_block[6:6 + len("LOANER01")] == b"LOANER01"
-    assert version_block.endswith(b"\x00" * (16 - len("*OEFW-") - len("LOANER01")))
-
-    # Verify CRC matches (xmodem polynomial)
-    payload, crc_bytes = data[:-2], data[-2:]
-    crc = crc_hqx(payload, 0x0000)
-    assert crc_bytes == bytes([crc & 0xFF, (crc >> 8) & 0xFF])
+	data = packed_bin.read_bytes()
+	assert len(data) == len(plain) + PACKER.METADATA_SIZE + 2
+	assert PACKER.inspect_firmware(data) == "LOANR01"
+	assert result.stdout.strip() == "LOANR01"
 
 
-def test_fw_pack_rejects_long_version(tmp_path):
-    input_bin = tmp_path / "input.bin"
-    input_bin.write_bytes(b"\x00" * 0x2100)
-    packed_bin = tmp_path / "output.bin"
+@pytest.mark.parametrize("suffix", ["short", "TOO-LNG", "lower01", "TOOLONG8"])
+def test_fw_pack_rejects_invalid_suffixes(tmp_path, suffix):
+	input_bin = tmp_path / "input.bin"
+	packed_bin = tmp_path / "output.bin"
+	input_bin.write_bytes(b"\x00" * 0x2100)
 
-    result = subprocess.run(
-        [sys.executable, "fw-pack.py", str(input_bin), "THIS_IS_TOO_LONG", str(packed_bin)],
-        capture_output=True,
-        text=True,
-    )
+	result = run_fw_pack("pack", input_bin, suffix, packed_bin, check=False)
 
-    assert result.returncode != 0
-    assert "Version suffix is too big" in result.stdout
-    assert not packed_bin.exists()
+	assert result.returncode != 0
+	assert "exactly 7 uppercase alphanumeric" in result.stderr
+	assert not packed_bin.exists()
+
+
+def test_fw_pack_rejects_small_input(tmp_path):
+	input_bin = tmp_path / "input.bin"
+	packed_bin = tmp_path / "output.bin"
+	input_bin.write_bytes(b"\x00" * (PACKER.METADATA_OFFSET - 1))
+
+	result = run_fw_pack("pack", input_bin, "LOANR01", packed_bin, check=False)
+
+	assert result.returncode != 0
+	assert "input firmware is too small" in result.stderr
+	assert not packed_bin.exists()
+
+
+def test_fw_pack_removes_stale_output_after_failure(tmp_path):
+	input_bin = tmp_path / "input.bin"
+	packed_bin = tmp_path / "output.bin"
+	input_bin.write_bytes(b"too small")
+	packed_bin.write_bytes(b"stale firmware")
+
+	result = run_fw_pack("pack", input_bin, "LOANR01", packed_bin, check=False)
+
+	assert result.returncode != 0
+	assert not packed_bin.exists()
+
+
+def test_fw_pack_rejects_corrupt_crc(tmp_path):
+	packed_bin = tmp_path / "output.bin"
+	packed = bytearray(PACKER.pack_firmware(b"\x00" * 0x2100, "LOANR01"))
+	packed[100] ^= 0x01
+	packed_bin.write_bytes(packed)
+
+	result = run_fw_pack("verify", packed_bin, "LOANR01", check=False)
+
+	assert result.returncode != 0
+	assert "CRC mismatch" in result.stderr
+
+
+def test_fw_pack_rejects_metadata_mismatch(tmp_path):
+	packed_bin = tmp_path / "output.bin"
+	packed_bin.write_bytes(PACKER.pack_firmware(b"\x00" * 0x2100, "LOANR01"))
+
+	result = run_fw_pack("verify", packed_bin, "LOANR02", check=False)
+
+	assert result.returncode != 0
+	assert "suffix mismatch" in result.stderr
+
+
+def test_fw_pack_requires_a_subcommand():
+	result = run_fw_pack(check=False)
+
+	assert result.returncode != 0
+	assert "required" in result.stderr

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -1,0 +1,138 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module(name, path):
+	spec = importlib.util.spec_from_file_location(name, Path(path))
+	assert spec is not None
+	assert spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+RELEASE = _load_module("release_artifacts", "ci/release_artifacts.py")
+PACKER = _load_module("firmware_packer_for_release", "fw-pack.py")
+
+
+@pytest.mark.parametrize(
+	("tag", "suffix"),
+	[
+		("v24.03", "LNR2430"),
+		("v24.10.5", "LNR24A5"),
+		("v24.12.35", "LNR24CZ"),
+	],
+)
+def test_tag_to_suffix(tag, suffix):
+	assert RELEASE.tag_to_suffix(tag) == suffix
+
+
+@pytest.mark.parametrize(
+	"tag",
+	["24.03", "v24.00", "v24.13", "v24.3", "v24.03.01", "v24.03.36", "v2024.03"],
+)
+def test_tag_to_suffix_rejects_invalid_tags(tag):
+	with pytest.raises(RELEASE.ReleaseError):
+		RELEASE.tag_to_suffix(tag)
+
+
+def test_validate_tag_rejects_suffix_file_drift(tmp_path):
+	suffix_file = tmp_path / "VERSION_SUFFIX"
+	suffix_file.write_text("LNR2431\n", encoding="ascii")
+
+	with pytest.raises(RELEASE.ReleaseError, match="expected LNR2430"):
+		RELEASE.validate_tag("v24.03", suffix_file)
+
+
+def test_release_bundle_records_and_verifies_integrity(tmp_path):
+	raw_path = tmp_path / "firmware.bin"
+	packed_path = tmp_path / "firmware.packed.bin"
+	output_dir = tmp_path / "release"
+	raw_path.write_bytes(b"\x5a" * 0x2200)
+	packed_path.write_bytes(PACKER.pack_firmware(raw_path.read_bytes(), "LNR24A5"))
+
+	manifest_path = RELEASE.bundle_artifacts(
+		suffix="LNR24A5",
+		raw_path=raw_path,
+		packed_path=packed_path,
+		output_dir=output_dir,
+		source_commit="a" * 40,
+		release_tag="v24.10.5",
+	)
+	RELEASE.verify_bundle(manifest_path, "LNR24A5", "v24.10.5")
+
+	manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+	assert manifest["source_commit"] == "a" * 40
+	assert manifest["firmware_ids"]["uart_handshake"] == "1.02.LNR24A5"
+	assert manifest["files"]["loaner-firmware-LNR24A5.bin"]["size"] == 0x2200
+	assert (output_dir / "loaner-firmware-LNR24A5.sha256").is_file()
+
+
+def test_release_bundle_detects_artifact_changes(tmp_path):
+	raw_path = tmp_path / "firmware.bin"
+	packed_path = tmp_path / "firmware.packed.bin"
+	output_dir = tmp_path / "release"
+	raw_path.write_bytes(b"\x5a" * 0x2200)
+	packed_path.write_bytes(PACKER.pack_firmware(raw_path.read_bytes(), "LNR24A5"))
+	manifest_path = RELEASE.bundle_artifacts(
+		suffix="LNR24A5",
+		raw_path=raw_path,
+		packed_path=packed_path,
+		output_dir=output_dir,
+		source_commit="b" * 40,
+		release_tag="v24.10.5",
+	)
+	(output_dir / "loaner-firmware-LNR24A5.bin").write_bytes(b"changed")
+
+	with pytest.raises(RELEASE.ReleaseError, match="size mismatch"):
+		RELEASE.verify_bundle(manifest_path, "LNR24A5", "v24.10.5")
+
+
+def test_release_bundle_rejects_packed_image_from_different_raw_firmware(tmp_path):
+	raw_path = tmp_path / "firmware.bin"
+	packed_path = tmp_path / "firmware.packed.bin"
+	raw_path.write_bytes(b"\x5a" * 0x2200)
+	packed_path.write_bytes(PACKER.pack_firmware(b"\xa5" * 0x2200, "LNR24A5"))
+
+	with pytest.raises(RELEASE.ReleaseError, match="does not match the raw firmware"):
+		RELEASE.bundle_artifacts(
+			suffix="LNR24A5",
+			raw_path=raw_path,
+			packed_path=packed_path,
+			output_dir=tmp_path / "release",
+			source_commit="c" * 40,
+			release_tag="v24.10.5",
+		)
+
+
+def test_validate_tag_cli_writes_github_outputs(tmp_path):
+	suffix_file = tmp_path / "VERSION_SUFFIX"
+	github_output = tmp_path / "github-output"
+	suffix_file.write_text("LNR24A5\n", encoding="ascii")
+
+	result = subprocess.run(
+		[
+			sys.executable,
+			"ci/release_artifacts.py",
+			"validate-tag",
+			"--tag",
+			"v24.10.5",
+			"--suffix-file",
+			str(suffix_file),
+			"--github-output",
+			str(github_output),
+		],
+		check=True,
+		capture_output=True,
+		text=True,
+	)
+
+	assert result.stdout.strip() == "LNR24A5"
+	assert github_output.read_text(encoding="utf-8") == (
+		"version_suffix=LNR24A5\nartifact_stem=loaner-firmware-LNR24A5\n"
+	)


### PR DESCRIPTION
## Summary

- define one deterministic mapping from `vYY.MM[.PATCH]` release tags to seven-character firmware suffixes (`LNRYYMP`, with base-36 month and patch digits)
- make firmware packing a required, fail-closed build step and add explicit CRC/metadata verification
- publish suffix-bearing raw and packed images with a JSON manifest and SHA-256 checksum file
- record source commit, raw/packed sizes and hashes, firmware identifiers, ARM toolchain versions, Python version, and packer schema
- restrict release triggers, verify tag/suffix agreement before building, and refuse to overwrite an existing GitHub release
- add automated tag, CLI, undersized-input, stale-output, CRC, metadata, raw/packed pairing, manifest, and tamper tests
- align build and release documentation with the enforced workflow

## Version mapping

The release tag mapping is `LNRYYMP`, where month and patch use one base-36 digit:

- `v24.03` -> `LNR2430`
- `v24.10.5` -> `LNR24A5`
- `v24.12.35` -> `LNR24CZ`

An omitted patch maps to `0`; patches above 35 and invalid calendar months are rejected. The current root suffix `LNR2415` therefore maps to `v24.01.5`.

## Release safety

- malformed tags or a mismatched `VERSION_SUFFIX` fail before the build
- packer errors remove stale output instead of leaving an old image available
- packed CRC, prefix, suffix, padding, and raw-to-packed correspondence are verified
- release artifacts have immutable suffix-bearing names
- existing releases are never updated by the normal tag workflow
- no release or tag is created by this PR

## Validation

- full Docker pipeline: passed
- pytest: 93 passed
- changed-line clang-format 14.0.6: passed
- cppcheck: passed
- ARM firmware build: 51,444 bytes
- tagged bundle simulation using `v24.01.5` / `LNR2415`: passed
- independent manifest, checksum, packed metadata, and artifact-pair verification: passed
- Ruff: passed
- ShellCheck: passed
- actionlint across all GitHub workflows: passed

No firmware runtime behavior changes and no hardware validation is required.

Closes #42