### PR TITLE
Make firmware builds deterministic

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+/.git
+**/.git
+/.docker-format.*
+/compiled-firmware
+/firmware
+/firmware.bin
+/firmware.packed.bin
+/loaner-firmware
+/loaner-firmware.bin
+/loaner-firmware.packed.bin
+*.d
+*.o
+**/__pycache__
+/.pytest_cache
+/.ruff_cache

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -18,6 +18,7 @@ jobs:
       security-events: write
     env:
       VERSION_SUFFIX: LNR2413
+      SOURCE_COMMIT: ${{ github.sha }}
 
     strategy:
       fail-fast: false
@@ -26,22 +27,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: recursive
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
         with:
           languages: ${{ matrix.language }}
 
-      - name: Install ARM GCC toolchain
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi
+      - name: Install verified ARM GCC toolchain
+        run: bash ci/install-arm-toolchain.sh "${RUNNER_TEMP}"
 
       - name: Build firmware
         run: make -j"$(nproc)"
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,18 +18,18 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12'
+          python-version: '3.12.11'
 
       - name: Install linters
         run: |
-          python -m pip install --upgrade pip ruff==0.5.6
+          python -m pip install --disable-pip-version-check -r ci/requirements-ci.txt
           sudo apt-get update
-          sudo apt-get install -y shellcheck
+          sudo apt-get install -y shellcheck=0.8.0-2
 
       - name: Ruff (pyflakes)
         run: python -m ruff check fw-pack.py ci/release_artifacts.py tests
@@ -42,17 +42,17 @@ jobs:
     needs: style
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12'
+          python-version: '3.12.11'
 
       - name: Install pinned clang-format
-        run: python -m pip install -r ci/requirements-format.txt
+        run: python -m pip install --disable-pip-version-check -r ci/requirements-ci.txt
 
       - name: Check formatting
         run: ci/check-clang-format.sh
@@ -62,12 +62,12 @@ jobs:
     needs: [style, clang-format]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install cppcheck
         run: |
           sudo apt-get update
-          sudo apt-get install -y cppcheck
+          sudo apt-get install -y cppcheck=2.7-1
 
       - name: Run cppcheck
         run: CI_MODE=cppcheck ./ci/run.sh
@@ -81,7 +81,7 @@ jobs:
       COMPAT_SUFFIX: LNR2414
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Clone CHIRP sources
         run: git clone --depth 1 --branch "$CHIRP_REF" "$CHIRP_REPO" chirp-src
@@ -107,18 +107,18 @@ jobs:
     needs: [style, clang-format, cppcheck, chirp-compat]
     strategy:
       matrix:
-        python-version: ['3.10', '3.12']
+        python-version: ['3.10.18', '3.12.11']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: python -m pip install --upgrade pip pytest
+        run: python -m pip install --disable-pip-version-check -r ci/requirements-ci.txt
 
       - name: Run pytest
         run: pytest -q
@@ -129,7 +129,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           submodules: recursive
@@ -158,7 +158,7 @@ jobs:
         run: ls -l compiled-firmware
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: github.event_name == 'workflow_dispatch'
         with:
           name: loaner-firmware-${{ github.event.inputs.version_suffix }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           submodules: recursive
@@ -58,7 +58,7 @@ jobs:
         run: ls -l compiled-firmware
 
       - name: Upload workflow artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ steps.release.outputs.artifact_stem }}
           path: compiled-firmware/loaner-firmware-*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## Build, Test, and Development Commands
 - `make` (or `win_make.bat`) builds both the raw and required packed firmware; a packing or metadata failure fails the build.
-- `./compile-with-docker.sh` supplies a reproducible GCC 10.3.1 toolchain and writes artifacts to `compiled-firmware/`.
+- `./compile-with-docker.sh` uses the pinned container and checksum-verified GCC 10.3.1 toolchain, proves two clean builds are byte-identical, and writes artifacts to `compiled-firmware/`.
 - `make clean` clears objects before benchmarking size; `make flash`/`make debug` expect OpenOCD with a J-Link config.
 - `python3 fw-pack.py pack loaner-firmware.bin LNR24A5 loaner-firmware.packed.bin` injects metadata; use the `verify` subcommand before publishing an image.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -6,7 +6,7 @@ This document covers local builds, validation, firmware packing, and releases.
 
 - Docker for the recommended build path.
 - For native builds: ARM GCC 10.3.1 on `PATH`, GNU Make, and Python 3.
-- For native validation: `cppcheck`, `pytest`, and the pinned formatter from `ci/requirements-format.txt`.
+- For native validation: `cppcheck`, `shellcheck`, and the pinned Python tools from `ci/requirements-ci.txt`.
 
 ## Docker Build (recommended)
 
@@ -16,14 +16,14 @@ Run the complete validation and build pipeline with an exact seven-character upp
 VERSION_SUFFIX=LNR2415 ./compile-with-docker.sh
 ```
 
-The wrapper runs the formatting check, cppcheck, pytest, and the ARM build. It writes a verified bundle to `compiled-firmware/`:
+The wrapper runs the formatting check, cppcheck, pytest, and two clean ARM builds. The two raw images and two packed images must be byte-identical before it writes a verified bundle to `compiled-firmware/`:
 
 - `loaner-firmware-LNR2415.bin`
 - `loaner-firmware-LNR2415.packed.bin`
 - `loaner-firmware-LNR2415.manifest.json`
 - `loaner-firmware-LNR2415.sha256`
 
-The manifest records file sizes and hashes, the source commit, firmware identifiers, and build-tool versions. The checksum file covers both images and the manifest.
+The manifest records file sizes and hashes, the source commit, firmware identifiers, and build-tool versions. The checksum file covers both images and the manifest. The Docker base, dated Arch package repository, Python packages, Arm archive checksum, and GitHub Actions are pinned; see `ci/dependencies.md` for the reviewed values and update procedure.
 
 ## Native Build (optional)
 
@@ -48,14 +48,14 @@ The verifier checks the XMODEM CRC, `*OEFW-` metadata prefix, exact embedded suf
 The Docker wrapper is the canonical full check. Native equivalents are:
 
 ```sh
-python -m pip install -r ci/requirements-format.txt pytest
+python -m pip install -r ci/requirements-ci.txt
 ci/check-clang-format.sh
 CI_MODE=cppcheck ci/run.sh
 pytest -q
 VERSION_SUFFIX=LNR2415 ci/run.sh
 ```
 
-GitHub Actions runs tests under Python 3.10 and 3.12, checks CHIRP compatibility, runs CodeQL, and performs the Docker firmware build. Keep the firmware below `MAX_FIRMWARE_SIZE` (122880 bytes by default).
+GitHub Actions runs tests under Python 3.10.18 and 3.12.11, checks CHIRP compatibility, runs CodeQL, and performs the Docker firmware build. Docker builds export the changed-line formatting diff on the host and mount it read-only, so Git history never enters the image context. Keep the firmware below `MAX_FIRMWARE_SIZE` (122880 bytes by default).
 
 ## Release Version Mapping
 
@@ -81,7 +81,7 @@ Before tagging, write the resulting value to the root `VERSION_SUFFIX` file and 
 
 1. Create a release branch from current `main`.
 2. Pick a `vYY.MM[.PATCH]` tag and derive its suffix.
-3. Update `VERSION_SUFFIX`, build with that suffix, and run all checks.
+3. Update `VERSION_SUFFIX`, build with that suffix, and run all checks, including the two-build hash comparison.
 4. Flash the packed image and confirm the displayed version on hardware.
 5. Merge the release preparation PR.
 6. Tag the exact merge commit and push the annotated tag:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,33 @@
-FROM archlinux:latest
+# linux/amd64 image published 2026-07-27. Update this digest and the
+# ARCH_REPOSITORY_DATE together; see ci/dependencies.md.
+FROM archlinux:base-devel@sha256:33c534be6c990710a878b37192904dd448e162ade06a201d95a80b42be2110c7
 
+ARG ARCH_REPOSITORY_DATE=2026/07/28
 ARG TOOLCHAIN_VERSION=10.3-2021.10
-ARG TOOLCHAIN_ARCHIVE=gcc-arm-none-eabi-${TOOLCHAIN_VERSION}-x86_64-linux.tar.bz2
-ARG TOOLCHAIN_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/${TOOLCHAIN_VERSION}/${TOOLCHAIN_ARCHIVE}?rev=78196d3461ba4c9089a67b5f33edf82a&revision=78196d34-61ba-4c90-89a6-7b5f33edf82a&hash=B94A380A17942218223CD08320496FB1"
 
-RUN pacman -Syyu --noconfirm \
-    base-devel \
-    git \
-    python-pip \
-    python-pytest \
-    cppcheck \
-    ca-certificates \
-    curl \
-    tar
+COPY ci/container-packages.txt /tmp/container-packages.txt
 
-COPY ci/requirements-format.txt /tmp/requirements-format.txt
+RUN printf 'Server = https://archive.archlinux.org/repos/%s/$repo/os/$arch\n' \
+        "${ARCH_REPOSITORY_DATE}" > /etc/pacman.d/mirrorlist \
+    && pacman -Syyu --noconfirm --needed \
+        $(grep -Ev '^[[:space:]]*(#|$)' /tmp/container-packages.txt) \
+    && pacman -Scc --noconfirm
 
-RUN python -m pip install --break-system-packages --no-cache-dir \
-    -r /tmp/requirements-format.txt
+COPY ci/requirements-ci.txt /tmp/requirements-ci.txt
 
-RUN curl -L "${TOOLCHAIN_URL}" -o "/tmp/${TOOLCHAIN_ARCHIVE}" \
-    && tar -xjf "/tmp/${TOOLCHAIN_ARCHIVE}" -C /opt \
-    && rm "/tmp/${TOOLCHAIN_ARCHIVE}"
+RUN python -m pip install --break-system-packages --disable-pip-version-check \
+        --no-cache-dir -r /tmp/requirements-ci.txt
 
-ENV PATH="/opt/gcc-arm-none-eabi-${TOOLCHAIN_VERSION}/bin:${PATH}"
+COPY ci/install-arm-toolchain.sh ci/gcc-arm-none-eabi-10.3-2021.10.sha256 /tmp/toolchain/
+
+RUN bash /tmp/toolchain/install-arm-toolchain.sh /opt
+
+ENV BUILD_CONTAINER_BASE="archlinux:base-devel@sha256:33c534be6c990710a878b37192904dd448e162ade06a201d95a80b42be2110c7" \
+    BUILD_PACKAGE_SNAPSHOT="${ARCH_REPOSITORY_DATE}" \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PATH="/opt/gcc-arm-none-eabi-${TOOLCHAIN_VERSION}/bin:${PATH}" \
+    TZ=UTC
 
 WORKDIR /app
 COPY . .
-
-RUN git submodule update --init --recursive

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,8 @@ OBJCOPY = arm-none-eabi-objcopy
 SIZE = arm-none-eabi-size
 PYTHON ?= python3
 
-GIT_HASH := $(shell git rev-parse --short HEAD)
+SOURCE_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null)
+GIT_HASH := $(shell printf '%.7s' '$(SOURCE_COMMIT)')
 
 VERSION_SUFFIX ?= $(strip $(shell cat VERSION_SUFFIX 2>/dev/null))
 

--- a/ci/check-clang-format.sh
+++ b/ci/check-clang-format.sh
@@ -3,14 +3,61 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-REQUIREMENTS="${SCRIPT_DIR}/requirements-format.txt"
+REQUIREMENTS="${SCRIPT_DIR}/requirements-ci.txt"
 MODE="check"
+EXPORT_DIFF_FILE=""
 
 if [[ "${1:-}" == "--fix" ]]; then
 	MODE="fix"
 	shift
 elif [[ "${1:-}" == "--check" ]]; then
 	shift
+elif [[ "${1:-}" == "--export-diff" ]]; then
+	if [[ -z "${2:-}" ]]; then
+		echo "--export-diff requires an output path" >&2
+		exit 1
+	fi
+	EXPORT_DIFF_FILE="$2"
+	shift 2
+fi
+
+# Determine the base to diff against. On PRs GitHub exposes GITHUB_BASE_REF.
+if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+	BASE_REF="origin/${GITHUB_BASE_REF}"
+else
+	BASE_REF="${1:-origin/main}"
+fi
+
+cd "${ROOT}"
+
+source_diff() {
+	local MergeBase
+	local Path
+	local Status
+
+	if [[ "${BASE_REF}" == origin/* ]]; then
+		git fetch --no-tags origin "${BASE_REF#origin/}" >/dev/null 2>&1 || true
+	fi
+
+	if ! MergeBase="$(git merge-base "${BASE_REF}" HEAD)"; then
+		echo "Unable to find a merge base for ${BASE_REF}; fetch the base branch and retry" >&2
+		return 1
+	fi
+
+	git diff -U0 --no-color --relative --diff-filter=ACMRTUXB "${MergeBase}" -- '*.c' '*.h'
+	while IFS= read -r Path; do
+		Status=0
+		git diff --no-index -U0 --no-color -- /dev/null "${Path}" || Status=$?
+		if ((Status > 1)); then
+			return "${Status}"
+		fi
+	done < <(git ls-files --others --exclude-standard -- '*.c' '*.h')
+}
+
+if [[ -n "${EXPORT_DIFF_FILE}" ]]; then
+	source_diff > "${EXPORT_DIFF_FILE}"
+	echo "Exported C source diff from ${BASE_REF} to ${EXPORT_DIFF_FILE}."
+	exit 0
 fi
 
 FORMATTER="${CLANG_FORMAT_BIN:-clang-format}"
@@ -38,46 +85,18 @@ if [[ "${ACTUAL_VERSION}" != *"version ${EXPECTED_VERSION}"* ]]; then
 	exit 1
 fi
 
-# Determine the base to diff against. On PRs GitHub exposes GITHUB_BASE_REF.
-if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
-	BASE_REF="origin/${GITHUB_BASE_REF}"
-else
-	BASE_REF="${1:-origin/main}"
-fi
-
-cd "${ROOT}"
-
-if [[ "${BASE_REF}" == origin/* ]]; then
-	git fetch --no-tags origin "${BASE_REF#origin/}" >/dev/null 2>&1 || true
-fi
-
-if ! MERGE_BASE="$(git merge-base "${BASE_REF}" HEAD)"; then
-	echo "Unable to find a merge base for ${BASE_REF}; fetch the base branch and retry" >&2
-	exit 1
-fi
-
-source_diff() {
-	local Path
-	local Status
-
-	git diff -U0 --no-color --relative --diff-filter=ACMRTUXB "${MERGE_BASE}" -- '*.c' '*.h'
-	while IFS= read -r Path; do
-		Status=0
-		git diff --no-index -U0 --no-color -- /dev/null "${Path}" || Status=$?
-		if ((Status > 1)); then
-			return "${Status}"
-		fi
-	done < <(git ls-files --others --exclude-standard -- '*.c' '*.h')
-}
-
 format_diff() {
-	source_diff |
+	if [[ -n "${CLANG_FORMAT_DIFF_FILE:-}" ]]; then
+		cat -- "${CLANG_FORMAT_DIFF_FILE}"
+	else
+		source_diff
+	fi |
 		"${FORMAT_DIFF}" -p1 -binary "${FORMATTER}" "$@"
 }
 
 if [[ "${MODE}" == "fix" ]]; then
 	format_diff -i
-	echo "clang-format applied to C lines changed from ${BASE_REF}."
+	echo "clang-format applied to changed C lines."
 	exit 0
 fi
 
@@ -89,4 +108,4 @@ if [[ -n "${DIFF}" ]]; then
 	exit 1
 fi
 
-echo "clang-format ${EXPECTED_VERSION} check passed for lines changed from ${BASE_REF}."
+echo "clang-format ${EXPECTED_VERSION} check passed for changed C lines."

--- a/ci/check-reproducible-build.sh
+++ b/ci/check-reproducible-build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FIRST_BUILD="$(mktemp -d)"
+
+cleanup() {
+	rm -rf -- "${FIRST_BUILD}"
+}
+trap cleanup EXIT
+
+: "${VERSION_SUFFIX:?VERSION_SUFFIX is required}"
+
+cd "${ROOT}"
+
+build_firmware() {
+	make clean
+	make TARGET=loaner-firmware VERSION_SUFFIX="${VERSION_SUFFIX}"
+}
+
+echo "Building reproducibility sample 1 of 2..."
+build_firmware
+cp loaner-firmware.bin loaner-firmware.packed.bin "${FIRST_BUILD}/"
+
+echo "First-build hashes:"
+sha256sum "${FIRST_BUILD}/loaner-firmware.bin" \
+	"${FIRST_BUILD}/loaner-firmware.packed.bin"
+
+echo "Building reproducibility sample 2 of 2..."
+build_firmware
+
+cmp "${FIRST_BUILD}/loaner-firmware.bin" loaner-firmware.bin
+cmp "${FIRST_BUILD}/loaner-firmware.packed.bin" loaner-firmware.packed.bin
+
+echo "Second-build hashes:"
+sha256sum loaner-firmware.bin loaner-firmware.packed.bin
+echo "Reproducibility check passed: raw and packed firmware are byte-identical."

--- a/ci/container-packages.txt
+++ b/ci/container-packages.txt
@@ -1,0 +1,9 @@
+# Versions are frozen by the dated Arch Linux Archive repository in Dockerfile.
+bzip2
+ca-certificates
+cppcheck
+curl
+python
+python-pip
+shellcheck
+tar

--- a/ci/dependencies.md
+++ b/ci/dependencies.md
@@ -1,0 +1,43 @@
+# Pinned build dependencies
+
+Release builds use immutable or dated inputs so rebuilding the same commit and
+firmware suffix can reproduce the same raw and packed images.
+
+## Container
+
+- Base: `archlinux:base-devel` for `linux/amd64`
+- Manifest digest: `sha256:33c534be6c990710a878b37192904dd448e162ade06a201d95a80b42be2110c7`
+- Arch package snapshot: `2026/07/28`
+- Package list: `ci/container-packages.txt`
+
+Update the image digest and repository date together. Build twice with the
+same source commit and suffix before accepting the update. Both values and the
+commit-derived `SOURCE_DATE_EPOCH` are recorded in each release manifest.
+
+## Arm compiler
+
+- Archive: `gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2`
+- SHA-256: `97dbb4f019ad1650b732faffcc881689cedc14e2b7ee863d390e0a41ef16c9a3`
+- Official MD5 cross-check: `2383e4eb4ea23f248d33adc70dc3227e`
+
+`ci/install-arm-toolchain.sh` verifies the committed SHA-256 before extracting
+the archive. Update the URL, checksum file, and documented versions together.
+
+## Python
+
+GitHub Actions uses Python `3.10.18` and `3.12.11`. Direct and transitive test,
+lint, and formatting packages are pinned in `ci/requirements-ci.txt`.
+
+## GitHub Actions
+
+Workflow `uses:` entries are pinned to full commit SHAs with the reviewed
+release version in an inline comment. To update one, review the upstream
+release notes, replace both the SHA and comment, run actionlint, and complete
+the two-build firmware comparison.
+
+| Action | Reviewed version | Commit |
+| --- | --- | --- |
+| `actions/checkout` | `v4.4.0` | `11d5960a326750d5838078e36cf38b85af677262` |
+| `actions/setup-python` | `v5.6.0` | `a26af69be951a213d495a4c3e4e4022e16d87065` |
+| `actions/upload-artifact` | `v4.6.2` | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
+| `github/codeql-action` | `v3.37.3` | `4187e74d05793876e9989daffde9c3e66b4acd07` |

--- a/ci/gcc-arm-none-eabi-10.3-2021.10.sha256
+++ b/ci/gcc-arm-none-eabi-10.3-2021.10.sha256
@@ -1,0 +1,1 @@
+97dbb4f019ad1650b732faffcc881689cedc14e2b7ee863d390e0a41ef16c9a3  gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2

--- a/ci/install-arm-toolchain.sh
+++ b/ci/install-arm-toolchain.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TOOLCHAIN_VERSION="10.3-2021.10"
+TOOLCHAIN_ARCHIVE="gcc-arm-none-eabi-${TOOLCHAIN_VERSION}-x86_64-linux.tar.bz2"
+TOOLCHAIN_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/${TOOLCHAIN_VERSION}/${TOOLCHAIN_ARCHIVE}?rev=78196d3461ba4c9089a67b5f33edf82a&revision=78196d34-61ba-4c90-89a6-7b5f33edf82a&hash=B94A380A17942218223CD08320496FB1"
+CHECKSUM_FILE="${SCRIPT_DIR}/gcc-arm-none-eabi-${TOOLCHAIN_VERSION}.sha256"
+DESTINATION="${1:-/opt}"
+DOWNLOAD_DIR="$(mktemp -d)"
+
+cleanup() {
+	rm -rf -- "${DOWNLOAD_DIR}"
+}
+trap cleanup EXIT
+
+mkdir -p "${DESTINATION}"
+curl --fail --location --retry 3 --output "${DOWNLOAD_DIR}/${TOOLCHAIN_ARCHIVE}" \
+	"${TOOLCHAIN_URL}"
+
+(
+	cd "${DOWNLOAD_DIR}"
+	sha256sum --check "${CHECKSUM_FILE}"
+)
+
+tar -xjf "${DOWNLOAD_DIR}/${TOOLCHAIN_ARCHIVE}" -C "${DESTINATION}"
+
+TOOLCHAIN_BIN="${DESTINATION}/gcc-arm-none-eabi-${TOOLCHAIN_VERSION}/bin"
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+	echo "${TOOLCHAIN_BIN}" >> "${GITHUB_PATH}"
+fi
+
+"${TOOLCHAIN_BIN}/arm-none-eabi-gcc" --version | head -n 1
+"${TOOLCHAIN_BIN}/arm-none-eabi-ld" --version | head -n 1

--- a/ci/release_artifacts.py
+++ b/ci/release_artifacts.py
@@ -4,6 +4,7 @@ import argparse
 import hashlib
 import importlib.util
 import json
+import os
 import platform
 import re
 import shutil
@@ -131,6 +132,11 @@ def bundle_artifacts(
 		"schema": MANIFEST_SCHEMA,
 		"release_tag": release_tag,
 		"source_commit": source_commit,
+		"build_environment": {
+			"container_base": os.environ.get("BUILD_CONTAINER_BASE", "unavailable"),
+			"package_snapshot": os.environ.get("BUILD_PACKAGE_SNAPSHOT", "unavailable"),
+			"source_date_epoch": os.environ.get("SOURCE_DATE_EPOCH", "unavailable"),
+		},
 		"version_suffix": suffix,
 		"firmware_ids": {
 			"display_banner": f"OEFW-{suffix}",

--- a/ci/requirements-ci.txt
+++ b/ci/requirements-ci.txt
@@ -1,0 +1,10 @@
+# Direct and transitive Python dependencies used by repository CI.
+# Update as one reviewed set and validate on Python 3.10.18 and 3.12.11.
+clang-format==14.0.6
+colorama==0.4.6
+iniconfig==2.3.0
+packaging==26.2
+pluggy==1.6.0
+pygments==2.20.0
+pytest==8.4.2
+ruff==0.5.6

--- a/ci/requirements-format.txt
+++ b/ci/requirements-format.txt
@@ -1,1 +1,0 @@
-clang-format==14.0.6

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -51,6 +51,18 @@ fi
 
 : "${VERSION_SUFFIX:?VERSION_SUFFIX is required (set a 7-character value such as VERSION_SUFFIX=LNR2415 before running this script)}"
 
+SOURCE_COMMIT="${SOURCE_COMMIT:-$(git rev-parse HEAD)}"
+if [[ ! "${SOURCE_COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+	echo "SOURCE_COMMIT must be a full 40-character lowercase Git SHA" >&2
+	exit 1
+fi
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git show -s --format=%ct "${SOURCE_COMMIT}")}"
+if [[ ! "${SOURCE_DATE_EPOCH}" =~ ^[0-9]+$ ]]; then
+	echo "SOURCE_DATE_EPOCH must be a non-negative integer" >&2
+	exit 1
+fi
+export SOURCE_COMMIT SOURCE_DATE_EPOCH
+
 mkdir -p "${ARTIFACT_DIR}"
 rm -f \
 	"${ARTIFACT_DIR}"/loaner-firmware-* \
@@ -65,9 +77,17 @@ run_cppcheck
 echo "Running unit tests..."
 pytest -q
 
-echo "Building firmware..."
-make clean
-make TARGET=loaner-firmware VERSION_SUFFIX="${VERSION_SUFFIX}"
+echo "Build inputs:"
+echo "  source commit: ${SOURCE_COMMIT}"
+echo "  source date epoch: ${SOURCE_DATE_EPOCH}"
+echo "  firmware suffix: ${VERSION_SUFFIX}"
+echo "  container base: ${BUILD_CONTAINER_BASE:-native}"
+echo "  package snapshot: ${BUILD_PACKAGE_SNAPSHOT:-native}"
+python3 --version
+arm-none-eabi-gcc --version | head -n 1
+arm-none-eabi-ld --version | head -n 1
+
+bash "${ROOT}/ci/check-reproducible-build.sh"
 
 BIN_SIZE=$(stat --format="%s" loaner-firmware.bin)
 MAX_SIZE=${MAX_FIRMWARE_SIZE:-122880}
@@ -78,7 +98,6 @@ fi
 
 echo "Firmware size: ${BIN_SIZE} bytes (limit ${MAX_SIZE})"
 
-SOURCE_COMMIT="${SOURCE_COMMIT:-$(git rev-parse HEAD)}"
 BUNDLE_ARGS=(
 	--suffix "${VERSION_SUFFIX}"
 	--source-commit "${SOURCE_COMMIT}"
@@ -96,5 +115,7 @@ if [[ -n "${RELEASE_TAG:-}" ]]; then
 fi
 
 echo "Creating verified artifact bundle..."
-python3 ci/release_artifacts.py bundle "${BUNDLE_ARGS[@]}"
+MANIFEST_PATH="$(python3 ci/release_artifacts.py bundle "${BUNDLE_ARGS[@]}")"
 python3 ci/release_artifacts.py verify-bundle "${VERIFY_ARGS[@]}"
+echo "Recorded build manifest:"
+cat "${MANIFEST_PATH}"

--- a/compile-with-docker.sh
+++ b/compile-with-docker.sh
@@ -16,20 +16,53 @@ fi
 
 SOURCE_COMMIT="${SOURCE_COMMIT:-$(git -C "${SCRIPT_DIR}" rev-parse HEAD)}"
 RELEASE_TAG="${RELEASE_TAG:-}"
+if [[ ! "${SOURCE_COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "SOURCE_COMMIT must be a full 40-character lowercase Git SHA" >&2
+  exit 1
+fi
+
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -C "${SCRIPT_DIR}" show -s --format=%ct "${SOURCE_COMMIT}")}"
+if [[ ! "${SOURCE_DATE_EPOCH}" =~ ^[0-9]+$ ]]; then
+  echo "SOURCE_DATE_EPOCH must be a non-negative integer" >&2
+  exit 1
+fi
+
+SUBMODULE_STATUS="$(git -C "${SCRIPT_DIR}" submodule status --recursive)"
+if grep -Eq '^[-+]' <<< "${SUBMODULE_STATUS}"; then
+  echo "Submodules must be initialized at their recorded commits before building" >&2
+  echo "${SUBMODULE_STATUS}" >&2
+  exit 1
+fi
 
 mkdir -p "${OUT_DIR}"
 
 rm -f \
   "${OUT_DIR}"/loaner-firmware-* \
   "${OUT_DIR}/loaner-firmware.bin" \
-  "${OUT_DIR}/loaner-firmware.packed.bin"
+  "${OUT_DIR}/loaner-firmware.packed.bin" \
+  "${OUT_DIR}/.source-format.diff"
+
+FORMAT_DIFF_FILE="${OUT_DIR}/.source-format.diff"
+cleanup() {
+  rm -f -- "${FORMAT_DIFF_FILE}"
+}
+trap cleanup EXIT
+
+"${SCRIPT_DIR}/ci/check-clang-format.sh" --export-diff "${FORMAT_DIFF_FILE}"
 
 docker build -t "${IMAGE_TAG}" "${SCRIPT_DIR}"
 
-docker run --rm \
-  -v "${OUT_DIR}":/app/compiled-firmware \
+DOCKER_OUT_DIR="${OUT_DIR}"
+if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]]; then
+  DOCKER_OUT_DIR="$(cygpath -w "${OUT_DIR}")"
+fi
+
+MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' docker run --rm \
+  -v "${DOCKER_OUT_DIR}:/app/compiled-firmware" \
+  -e CLANG_FORMAT_DIFF_FILE=compiled-firmware/.source-format.diff \
   -e VERSION_SUFFIX="${VERSION_SUFFIX}" \
   -e SOURCE_COMMIT="${SOURCE_COMMIT}" \
+  -e SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}" \
   -e RELEASE_TAG="${RELEASE_TAG}" \
   "${IMAGE_TAG}" \
-  /bin/bash -lc "cd /app && chmod +x ci/run.sh && ./ci/run.sh"
+  bash -lc "cd /app && chmod +x ci/run.sh && ./ci/run.sh"

--- a/tests/test_build_inputs.py
+++ b/tests/test_build_inputs.py
@@ -1,0 +1,78 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTION_PIN = re.compile(
+	r"uses:\s+[^@\s]+@(?P<sha>[0-9a-f]{40})\s+#\s+v[0-9]+\.[0-9]+\.[0-9]+\s*$"
+)
+EXACT_REQUIREMENT = re.compile(r"^[A-Za-z0-9_.-]+==[^=<>!~\s]+$")
+
+
+def test_all_workflow_actions_are_immutable_and_documented():
+	uses_lines = []
+	for workflow in sorted((ROOT / ".github" / "workflows").glob("*.yaml")):
+		for line_number, line in enumerate(workflow.read_text(encoding="utf-8").splitlines(), 1):
+			if "uses:" not in line:
+				continue
+			uses_lines.append((workflow, line_number, line.strip()))
+			assert ACTION_PIN.search(line), f"mutable or undocumented action at {workflow}:{line_number}"
+
+	assert uses_lines
+
+
+def test_python_ci_dependencies_are_exactly_pinned():
+	lines = (ROOT / "ci" / "requirements-ci.txt").read_text(encoding="utf-8").splitlines()
+	requirements = [line for line in lines if line and not line.startswith("#")]
+
+	assert requirements
+	assert all(EXACT_REQUIREMENT.fullmatch(requirement) for requirement in requirements)
+	assert len({requirement.split("==", 1)[0].lower() for requirement in requirements}) == len(
+		requirements
+	)
+
+
+def test_container_and_toolchain_inputs_are_pinned():
+	dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+	checksum = (
+		ROOT / "ci" / "gcc-arm-none-eabi-10.3-2021.10.sha256"
+	).read_text(encoding="ascii")
+
+	assert re.search(r"^FROM archlinux:base-devel@sha256:[0-9a-f]{64}$", dockerfile, re.MULTILINE)
+	assert re.search(
+		r"^ARG ARCH_REPOSITORY_DATE=[0-9]{4}/[0-9]{2}/[0-9]{2}$",
+		dockerfile,
+		re.MULTILINE,
+	)
+	assert "archlinux:latest" not in dockerfile
+	assert "BUILD_CONTAINER_BASE=" in dockerfile
+	assert 'BUILD_PACKAGE_SNAPSHOT="${ARCH_REPOSITORY_DATE}"' in dockerfile
+	assert re.fullmatch(
+		r"[0-9a-f]{64}  gcc-arm-none-eabi-10\.3-2021\.10-x86_64-linux\.tar\.bz2\n",
+		checksum,
+	)
+	assert "sha256sum --check" in (ROOT / "ci" / "install-arm-toolchain.sh").read_text(
+		encoding="utf-8"
+	)
+
+
+def test_docker_context_excludes_local_and_generated_state():
+	patterns = set((ROOT / ".dockerignore").read_text(encoding="utf-8").splitlines())
+
+	assert "/.git" in patterns
+	assert "/compiled-firmware" in patterns
+	assert "**/__pycache__" in patterns
+	assert "/.docker-format.*" in patterns
+
+
+def test_full_pipeline_requires_two_identical_builds():
+	run_script = (ROOT / "ci" / "run.sh").read_text(encoding="utf-8")
+	repro_script = (ROOT / "ci" / "check-reproducible-build.sh").read_text(encoding="utf-8")
+
+	assert "check-reproducible-build.sh" in run_script
+	assert repro_script.count("build_firmware") >= 3
+	assert 'cmp "${FIRST_BUILD}/loaner-firmware.bin" loaner-firmware.bin' in repro_script
+	assert (
+		'cmp "${FIRST_BUILD}/loaner-firmware.packed.bin" loaner-firmware.packed.bin'
+		in repro_script
+	)

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -68,6 +68,9 @@ def test_release_bundle_records_and_verifies_integrity(tmp_path):
 
 	manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 	assert manifest["source_commit"] == "a" * 40
+	assert manifest["build_environment"]["container_base"]
+	assert manifest["build_environment"]["package_snapshot"]
+	assert manifest["build_environment"]["source_date_epoch"]
 	assert manifest["firmware_ids"]["uart_handshake"] == "1.02.LNR24A5"
 	assert manifest["files"]["loaner-firmware-LNR24A5.bin"]["size"] == 0x2200
 	assert (output_dir / "loaner-firmware-LNR24A5.sha256").is_file()


### PR DESCRIPTION
## Summary

- pin the Arch Linux `base-devel` image to an immutable linux/amd64 digest and freeze package installation to the 2026-07-28 Arch Linux Archive snapshot
- verify the existing Arm GCC 10.3-2021.10 archive against a committed SHA-256 before extraction in Docker and CodeQL
- replace ad-hoc Python installs with one reviewed lock file covering direct and transitive CI dependencies
- pin all GitHub Actions to immutable commit SHAs with reviewed version comments and update documentation
- exclude Git history, generated firmware, objects, caches, and local state from the Docker context while retaining checked-out submodule contents
- pass the source commit and commit-derived `SOURCE_DATE_EPOCH` explicitly so the image no longer depends on `.git`
- build raw and packed firmware twice from clean objects and fail unless both pairs are byte-identical
- record the container digest, package snapshot, source epoch, compiler, linker, Python, packer, and source commit in CI/release manifest output
- preserve changed-line formatting checks without copying Git history by exporting the diff on the host and mounting it read-only
- make Docker volume handling work consistently on Linux and Windows Git Bash

## Reviewed inputs

- Arch base digest: `sha256:33c534be6c990710a878b37192904dd448e162ade06a201d95a80b42be2110c7`
- Arch package snapshot: `2026/07/28`
- Arm archive SHA-256: `97dbb4f019ad1650b732faffcc881689cedc14e2b7ee863d390e0a41ef16c9a3`
- Arm GCC: `10.3.1 20210824`
- Arm ld: `2.36.1.20210621`
- Python CI: `3.10.18` and `3.12.11`
- Actions: checkout `v4.4.0`, setup-python `v5.6.0`, upload-artifact `v4.6.2`, CodeQL `v3.37.3`, each pinned to its full commit

## Reproducibility proof

Two clean builds of source `fce2db973c62d0c712f3472eebc53cbd79efa6b7` with suffix `LNR2415` produced byte-identical files:

- raw: `147586b148e73bafa076aac6766cd6db3018eaa984c7dcfc3ffeeec0b0269483`
- packed: `dd6b4d247c5170d7077905d45a29a89d722f41365a1d408e6f51f189449808d4`

The hosted PR build will repeat the same proof for this PR's exact head commit.

## Validation

- full pinned Docker pipeline: passed
- pytest in Docker: 98 passed
- two clean ARM builds: byte-identical raw and packed firmware
- firmware size: 51,444 bytes
- manifest and checksum verification: passed
- Arm download checksum verification: passed
- cppcheck: passed
- clang-format 14.0.6: passed
- Ruff: passed
- ShellCheck: passed
- actionlint: passed
- Docker build definition/context check: passed
- Ubuntu 22.04 package pins verified for cppcheck and ShellCheck

No firmware runtime policy or radio behavior changes are included.

Closes #43