### PR TITLE
Pin upstream CHIRP compatibility tests

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -17,7 +17,6 @@ jobs:
       contents: read
       security-events: write
     env:
-      VERSION_SUFFIX: LNR2413
       SOURCE_COMMIT: ${{ github.sha }}
 
     strategy:
@@ -30,6 +29,12 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: recursive
+
+      - name: Load validated firmware suffix
+        run: |
+          SUFFIX="$(tr -d '\r\n' < VERSION_SUFFIX)"
+          python3 ci/release_artifacts.py validate-suffix "${SUFFIX}"
+          echo "VERSION_SUFFIX=${SUFFIX}" >> "${GITHUB_ENV}"
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -74,6 +74,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          submodules: recursive
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -108,7 +108,7 @@ jobs:
         run: bash ci/install-arm-toolchain.sh "${RUNNER_TEMP}"
 
       - name: Build firmware with the release suffix
-        run: make -j"$(nproc)" VERSION_SUFFIX="${VERSION_SUFFIX}"
+        run: make -j"$(nproc)" TARGET=loaner-firmware VERSION_SUFFIX="${VERSION_SUFFIX}"
 
       - name: Verify built firmware with CHIRP
         run: >-

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,10 +8,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      version_suffix:
-        description: 'Release VERSION_SUFFIX (e.g. LNR24B1). Required when manually triggering.'
-        required: false
 
 jobs:
   style:
@@ -32,7 +28,7 @@ jobs:
           sudo apt-get install -y shellcheck=0.8.0-2
 
       - name: Ruff (pyflakes)
-        run: python -m ruff check fw-pack.py ci/release_artifacts.py tests
+        run: python -m ruff check fw-pack.py ci tests
 
       - name: Shellcheck
         run: shellcheck compile-with-docker.sh ci/run.sh ci/check-clang-format.sh
@@ -75,32 +71,54 @@ jobs:
   chirp-compat:
     runs-on: ubuntu-22.04
     needs: [style, clang-format, cppcheck]
-    env:
-      CHIRP_REPO: https://github.com/aditaa/chirp.git
-      CHIRP_REF: loaner-firmware-whitelist
-      COMPAT_SUFFIX: LNR2414
     steps:
       - name: Checkout repo
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - name: Clone CHIRP sources
-        run: git clone --depth 1 --branch "$CHIRP_REF" "$CHIRP_REPO" chirp-src
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.10.18'
 
-      - name: Verify CHIRP compatibility
-        run: python3 ci/check-chirp-compat.py chirp-src
+      - name: Load validated compatibility inputs
+        run: |
+          SUFFIX="$(tr -d '\r\n' < VERSION_SUFFIX)"
+          python3 ci/release_artifacts.py validate-suffix "${SUFFIX}"
+          python3 ci/chirp_pin.py validate
+          {
+            echo "VERSION_SUFFIX=${SUFFIX}"
+            echo "CHIRP_REPOSITORY=$(python3 ci/chirp_pin.py get repository)"
+            echo "CHIRP_COMMIT=$(python3 ci/chirp_pin.py get commit)"
+          } >> "${GITHUB_ENV}"
+
+      - name: Fetch pinned upstream CHIRP commit
+        run: |
+          git init chirp-src
+          git -C chirp-src remote add origin "${CHIRP_REPOSITORY}"
+          git -C chirp-src fetch --depth 1 origin "${CHIRP_COMMIT}"
+          git -C chirp-src checkout --detach FETCH_HEAD
+          test "$(git -C chirp-src rev-parse HEAD)" = "${CHIRP_COMMIT}"
 
       - name: Install CHIRP test dependencies
-        run: |
-          cd chirp-src
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r test-requirements.txt pytest pytest-xdist
+        run: python3 -m pip install --disable-pip-version-check -r chirp-src/test-requirements.txt
+
+      - name: Install verified ARM GCC toolchain
+        run: bash ci/install-arm-toolchain.sh "${RUNNER_TEMP}"
+
+      - name: Build firmware with the release suffix
+        run: make -j"$(nproc)" VERSION_SUFFIX="${VERSION_SUFFIX}"
+
+      - name: Verify built firmware with CHIRP
+        run: >-
+          python3 ci/check-chirp-compat.py chirp-src loaner-firmware.bin
+          --suffix-file VERSION_SUFFIX
 
       - name: Run CHIRP UV-K5 driver tests
         working-directory: chirp-src
         env:
-          PYTHONPATH: ${PWD}/chirp-src
+          PYTHONPATH: ${{ github.workspace }}/chirp-src
           CHIRP_DEBUG: "y"
-        run: pytest --disable-warnings -k "uvk5" tests/test_drivers.py
+        run: python3 -m pytest --disable-warnings -k "uvk5" tests/test_drivers.py
 
   python-tests:
     runs-on: ubuntu-22.04
@@ -134,20 +152,9 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Derive version suffix
-        env:
-          REQUESTED_SUFFIX: ${{ github.event.inputs.version_suffix }}
+      - name: Load validated firmware suffix
         run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            if [[ -z "${REQUESTED_SUFFIX}" ]]; then
-              echo "VERSION_SUFFIX input is required when running manually" >&2
-              exit 1
-            fi
-            SUFFIX="${REQUESTED_SUFFIX}"
-          else
-            SUFFIX="CI${GITHUB_SHA::5}"
-            SUFFIX="${SUFFIX^^}"
-          fi
+          SUFFIX="$(tr -d '\r\n' < VERSION_SUFFIX)"
           python3 ci/release_artifacts.py validate-suffix "${SUFFIX}"
           echo "VERSION_SUFFIX=${SUFFIX}" >> "$GITHUB_ENV"
 
@@ -161,5 +168,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: github.event_name == 'workflow_dispatch'
         with:
-          name: loaner-firmware-${{ github.event.inputs.version_suffix }}
+          name: loaner-firmware-${{ env.VERSION_SUFFIX }}
           path: compiled-firmware/loaner-firmware-*

--- a/.github/workflows/update-chirp-pin.yaml
+++ b/.github/workflows/update-chirp-pin.yaml
@@ -1,0 +1,99 @@
+name: Update CHIRP pin
+
+on:
+  schedule:
+    - cron: '30 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.12.11'
+
+      - name: Resolve tracked CHIRP commit
+        id: chirp
+        run: |
+          python3 ci/chirp_pin.py validate
+          REPOSITORY="$(python3 ci/chirp_pin.py get repository)"
+          TRACK_REF="$(python3 ci/chirp_pin.py get track_ref)"
+          CURRENT="$(python3 ci/chirp_pin.py get commit)"
+          LATEST="$(git ls-remote "${REPOSITORY}" "${TRACK_REF}" | awk 'NR == 1 {print $1}')"
+          if [[ ! "${LATEST}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Unable to resolve a full CHIRP commit for ${TRACK_REF}" >&2
+            exit 1
+          fi
+          {
+            echo "current=${CURRENT}"
+            echo "latest=${LATEST}"
+            echo "track_ref=${TRACK_REF}"
+            if [[ "${CURRENT}" == "${LATEST}" ]]; then
+              echo "update=false"
+            else
+              echo "update=true"
+            fi
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Update lock file
+        if: steps.chirp.outputs.update == 'true'
+        run: python3 ci/chirp_pin.py update "${{ steps.chirp.outputs.latest }}"
+
+      - name: Commit and push dependency branch
+        if: steps.chirp.outputs.update == 'true'
+        id: branch
+        env:
+          LATEST: ${{ steps.chirp.outputs.latest }}
+        run: |
+          BRANCH="automation/chirp-pin-${LATEST:0:12}"
+          echo "name=${BRANCH}" >> "${GITHUB_OUTPUT}"
+          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "${BRANCH}"
+          git add ci/chirp.lock.json
+          git commit -m "Update CHIRP pin to ${LATEST:0:12}"
+          git push --set-upstream origin "${BRANCH}"
+          echo "exists=false" >> "${GITHUB_OUTPUT}"
+
+      - name: Open tracked dependency PR
+        if: >-
+          steps.chirp.outputs.update == 'true' &&
+          steps.branch.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.branch.outputs.name }}
+          CURRENT: ${{ steps.chirp.outputs.current }}
+          LATEST: ${{ steps.chirp.outputs.latest }}
+          TRACK_REF: ${{ steps.chirp.outputs.track_ref }}
+        run: |
+          BODY="$(printf "%s\n\n- Previous commit: \`%s\`\n- Candidate commit: \`%s\`\n- Tracked ref: \`%s\`\n\nCI validates the actual built firmware identifier and EEPROM mutations against this exact commit." \
+            'Automated CHIRP compatibility dependency update.' \
+            "${CURRENT}" "${LATEST}" "${TRACK_REF}")"
+          gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "Update CHIRP compatibility pin to ${LATEST:0:12}" \
+            --body "${BODY}"
+
+      - name: Dispatch compatibility CI for the dependency PR
+        if: >-
+          steps.chirp.outputs.update == 'true' &&
+          steps.branch.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.branch.outputs.name }}
+        run: gh workflow run main.yaml --ref "${BRANCH}"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The project also gives COML/COMT staff a predictable path from the ICS-205 form 
 - Unlocked transmit policy: regional lock presets do not restrict programmed memories. The firmware permits transmit throughout its defined 50–76 MHz and 108–600 MHz tuning bands; the person programming and operating each radio is responsible for choosing authorized frequencies, modes, power levels, and equipment.
 
 ## Programming Channel Plans With CHIRP
+
 This build assumes the channel plan lives on your ICS-205. To move that plan into a radio:
 
 1. Prepare the ICS-205 so each channel has a concise label (CHIRP shows up to seven characters by default).
@@ -38,21 +39,21 @@ This build assumes the channel plan lives on your ICS-205. To move that plan int
 5. Upload the plan with `Radio -> Upload To Radio`. After the radio reboots, rotate the channel knob and verify that the display shows the ICS-205 names.
 6. Repeat for each handset; the standard workflow keeps the handset in channel mode, so operators only see the memories you defined.
 
-### Detailed CHIRP workflow (UV-K5 + Egzumer/OSFW build)
+### Detailed upstream CHIRP workflow
 
-The loaner firmware reports the stock handshake string (`1.02.LNR2415`), so you can stay on the upstream CHIRP tree. Use the existing **Quansheng → UV-K5 (Plus / unsupported / OSFW)** driver entry that Egzumer added for the Plus/OSFW firmware:
+The radio reports `1.02.<VERSION_SUFFIX>` to programming software, which identifies its EEPROM layout as compatible with the upstream UV-K5 driver. The separate `OEFW-<VERSION_SUFFIX>` display banner gives field users the recognizable loaner label without changing CHIRP's compatibility contract.
 
-1. Update to the latest CHIRP daily build (or the Egzumer fork) so that “UV-K5 (Plus / unsupported / OSFW)” shows up under `Radio → Download From Radio`.
-2. Plug in the CH340 cable, switch the radio **on** (normal operation), and note the serial port name (`/dev/ttyUSB0`, `COM3`, etc.).
-3. In CHIRP choose `Radio → Download From Radio`, set **Vendor** to `Quansheng` and **Model** to `UV-K5 (Plus / unsupported / OSFW)`, then pick the serial port. Leave the radio unlocked; the loaner build keeps the keypad constrained but still answers the driver handshake.
-4. Once the download succeeds, edit memories as usual. Because the firmware only exposes 200 MR channels, keep your plan within that range.
-5. Upload with `Radio → Upload To Radio` using the same model selection. CHIRP will send the `1.02.LNR2415` identifier, which the radio accepts; the on-radio splash still says `OEFW-LNR2415` so field users see the loaner tag.
+1. Install a current CHIRP daily build from the upstream CHIRP project.
+2. Plug in the CH340 cable, switch the radio **on** in normal operating mode, and note the serial port name (`/dev/ttyUSB0`, `COM3`, etc.).
+3. In CHIRP choose `Radio -> Download From Radio`, set **Vendor** to `Quansheng` and **Model** to `UV-K5`, then select the serial port.
+4. Once the download succeeds, edit memories as usual. Keep the channel plan within memories 1 through 200.
+5. Upload with `Radio -> Upload To Radio` using the same model selection. After the radio restarts, verify the channel names against the ICS-205.
 
-If CHIRP warns that it cannot recognise the firmware, double-check that you selected the “Plus / unsupported / OSFW” entry—selecting the vanilla UV-K5 or K5 Plus targets will fail the version check.
+If CHIRP reports an unsupported firmware version, first confirm that the regular **Quansheng -> UV-K5** driver is selected and that the radio is running an official release artifact. Each release manifest records the exact upstream CHIRP commit tested by CI.
+
+The current firmware intentionally keeps the OEM-compatible EEPROM layout. If that layout ever changes, the firmware identifier must gain a compatibility-major version and CHIRP must gain a dedicated subclass; the design history is recorded in [kk7ds/chirp#1414](https://github.com/kk7ds/chirp/pull/1414).
 
 Tip: Keep a CHIRP image with the baseline loaner plan in source control so teams can diff changes before distributing updates. After each upload, rotate the knob and confirm the ICS-205 names match the paperwork.
-
-Tip: Keep a CHIRP image with the baseline loaner plan in source control so teams can diff changes before distributing updates.
 
 ## Flashing
 ### Quansheng PC Loader (recommended)

--- a/ci/check-chirp-compat.py
+++ b/ci/check-chirp-compat.py
@@ -1,113 +1,165 @@
 #!/usr/bin/env python3
-"""Ensure CHIRP still understands this firmware layout."""
+"""Ensure pinned upstream CHIRP understands the built firmware and memory layout."""
 
-import os
+import argparse
+import builtins
 import re
 import sys
-import builtins
 from pathlib import Path
 
 
+SUFFIX_PATTERN = re.compile(r"^[A-Z0-9]{7}$")
+FIRMWARE_ID_PATTERN = re.compile(rb"1\.02\.[A-Z0-9]{7}\x00")
+DISPLAY_BANNER_PATTERN = re.compile(rb"OEFW-[A-Z0-9]{7}\x00")
+
+
 def load_uvk5_module(chirp_root: Path):
-    sys.path.insert(0, str(chirp_root))
-    install_gettext_fallback()
-    try:
-        import chirp.drivers.uvk5 as uvk5  # type: ignore
-    except ImportError as exc:
-        raise RuntimeError(f"Unable to import chirp.drivers.uvk5: {exc}") from exc
-    return uvk5
+	sys.path.insert(0, str(chirp_root))
+	install_gettext_fallback()
+	try:
+		import chirp.drivers.uvk5 as uvk5  # type: ignore
+	except ImportError as exc:
+		raise RuntimeError(f"Unable to import chirp.drivers.uvk5: {exc}") from exc
+	return uvk5
 
 
 def install_gettext_fallback():
-    if getattr(builtins, "_", None):
-        return
+	if getattr(builtins, "_", None):
+		return
 
-    def _identity(message, *args, **kwargs):
-        return message
+	def _identity(message, *args, **kwargs):
+		return message
 
-    builtins._ = _identity
+	builtins._ = _identity
+
+
+def read_suffix(suffix_file: Path) -> str:
+	try:
+		suffix = suffix_file.read_text(encoding="ascii").strip()
+	except OSError as error:
+		raise RuntimeError(f"Unable to read firmware suffix from {suffix_file}: {error}") from error
+	if not SUFFIX_PATTERN.fullmatch(suffix):
+		raise RuntimeError("Firmware suffix must be exactly 7 uppercase alphanumeric characters")
+	return suffix
+
+
+def _extract_unique(raw: bytes, pattern: re.Pattern[bytes], label: str) -> str:
+	matches = {match[:-1].decode("ascii") for match in pattern.findall(raw)}
+	if len(matches) != 1:
+		raise RuntimeError(
+			f"Built firmware must contain exactly one unique {label}; found {sorted(matches)}"
+		)
+	return matches.pop()
+
+
+def extract_firmware_ids(binary_path: Path, expected_suffix: str) -> tuple[str, str]:
+	try:
+		raw = binary_path.read_bytes()
+	except OSError as error:
+		raise RuntimeError(f"Unable to read built firmware {binary_path}: {error}") from error
+
+	firmware_id = _extract_unique(raw, FIRMWARE_ID_PATTERN, "UART programming identifier")
+	display_banner = _extract_unique(raw, DISPLAY_BANNER_PATTERN, "display banner")
+	if firmware_id != f"1.02.{expected_suffix}":
+		raise RuntimeError(
+			f"Built UART identifier is {firmware_id}, expected 1.02.{expected_suffix}"
+		)
+	if display_banner != f"OEFW-{expected_suffix}":
+		raise RuntimeError(
+			f"Built display banner is {display_banner}, expected OEFW-{expected_suffix}"
+		)
+	return firmware_id, display_banner
 
 
 def check_memory_bounds(misc_path: Path):
-    data = misc_path.read_text()
+	data = misc_path.read_text(encoding="utf-8")
 
-    def extract(name: str) -> int:
-        match = re.search(rf"{name} = (\d+)U", data)
-        if not match:
-            raise RuntimeError(f"Unable to locate {name} in {misc_path}")
-        return int(match.group(1))
+	def extract(name: str) -> int:
+		match = re.search(rf"{name} = (\d+)U", data)
+		if not match:
+			raise RuntimeError(f"Unable to locate {name} in {misc_path}")
+		return int(match.group(1))
 
-    mr_last = extract("MR_CHANNEL_LAST")
-    freq_first = extract("FREQ_CHANNEL_FIRST")
+	mr_last = extract("MR_CHANNEL_LAST")
+	freq_first = extract("FREQ_CHANNEL_FIRST")
 
-    if mr_last != 199:
-        raise RuntimeError(f"Firmware MR channel bound is {mr_last}, expected 199.")
-
-    if freq_first != 200:
-        raise RuntimeError(f"Firmware VFO channel start is {freq_first}, expected 200.")
-
-
-def exercise_driver(module, banner):
-    from chirp import chirp_common, errors, bitwise, memmap  # type: ignore
-
-    class DummyPipe:
-        def log(self, *args, **kwargs):
-            pass
-
-    raw = memmap.MemoryMapBytes(b"\x00" * getattr(module, "MEM_SIZE", 0x2000))
-    radio = module.UVK5Radio(DummyPipe())
-    radio.metadata = {"uvk5_firmware": banner}
-    radio._mmap = raw
-    radio._memobj = bitwise.parse(module.MEM_FORMAT, radio._mmap)
-
-    mem = radio.get_memory(1)
-    mem.name = "CI-CHECK"
-    radio.set_memory(mem)
-
-    failing = chirp_common.Memory()
-    failing.number = 250
-    failing.empty = False
-    try:
-        radio.set_memory(failing)
-        raise RuntimeError("CHIRP accepted channel 250; memory bounds may be misaligned")
-    except (errors.RadioError, IndexError):
-        pass
-
-    settings = radio.get_settings()
-    for group in settings:
-        for setting in group:
-            try:
-                _ = setting.value
-            except Exception:
-                continue
-
-    baseline = raw.get_packed()
-    temp_mem = radio.get_memory(2)
-    temp_mem.empty = True
-    radio.set_memory(temp_mem)
-    if raw.get_packed() == baseline:
-        raise RuntimeError("CHIRP memory operations did not modify the image; layout may have changed")
+	if mr_last != 199:
+		raise RuntimeError(f"Firmware MR channel bound is {mr_last}, expected 199.")
+	if freq_first != 200:
+		raise RuntimeError(f"Firmware VFO channel start is {freq_first}, expected 200.")
 
 
-def main():
-    if len(sys.argv) != 2:
-        print("Usage: check-chirp-compat.py <path-to-chirp>", file=sys.stderr)
-        sys.exit(1)
+def exercise_driver(module, firmware_id):
+	from chirp import bitwise, chirp_common, errors, memmap  # type: ignore
 
-    chirp_root = Path(sys.argv[1]).resolve()
-    module = load_uvk5_module(chirp_root)
+	class DummyPipe:
+		def log(self, *args, **kwargs):
+			pass
 
-    suffix = os.environ.get("COMPAT_SUFFIX", "LNR2415")
-    firmware_id = f"1.02.{suffix}"
-    if not module.UVK5Radio.k5_approve_firmware(firmware_id):
-        raise RuntimeError(f"CHIRP rejected firmware identifier {firmware_id}")
+	raw = memmap.MemoryMapBytes(b"\x00" * getattr(module, "MEM_SIZE", 0x2000))
+	radio = module.UVK5Radio(DummyPipe())
+	radio.metadata = {"uvk5_firmware": firmware_id}
+	radio._mmap = raw
+	radio._memobj = bitwise.parse(module.MEM_FORMAT, radio._mmap)
 
-    firmware_root = Path(__file__).resolve().parents[1]
-    check_memory_bounds(firmware_root / "misc.h")
-    exercise_driver(module, firmware_id)
+	mem = radio.get_memory(1)
+	mem.name = "CI-CHECK"
+	radio.set_memory(mem)
 
-    print(f"CHIRP accepts firmware identifier '{firmware_id}' and driver tests passed.")
+	failing = chirp_common.Memory()
+	failing.number = 250
+	failing.empty = False
+	try:
+		radio.set_memory(failing)
+		raise RuntimeError("CHIRP accepted channel 250; memory bounds may be misaligned")
+	except (errors.RadioError, IndexError):
+		pass
+
+	settings = radio.get_settings()
+	for group in settings:
+		for setting in group:
+			try:
+				_ = setting.value
+			except Exception:
+				continue
+
+	baseline = raw.get_packed()
+	temp_mem = radio.get_memory(2)
+	temp_mem.empty = True
+	radio.set_memory(temp_mem)
+	if raw.get_packed() == baseline:
+		raise RuntimeError("CHIRP memory operations did not modify the image; layout may have changed")
+
+
+def build_parser() -> argparse.ArgumentParser:
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument("chirp_root", type=Path)
+	parser.add_argument("firmware_binary", type=Path)
+	parser.add_argument("--suffix-file", type=Path, default=Path("VERSION_SUFFIX"))
+	return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+	args = build_parser().parse_args(argv)
+	try:
+		suffix = read_suffix(args.suffix_file)
+		firmware_id, display_banner = extract_firmware_ids(args.firmware_binary, suffix)
+		module = load_uvk5_module(args.chirp_root.resolve())
+		if not module.UVK5Radio.k5_approve_firmware(firmware_id):
+			raise RuntimeError(f"CHIRP rejected built firmware identifier {firmware_id}")
+
+		firmware_root = Path(__file__).resolve().parents[1]
+		check_memory_bounds(firmware_root / "misc.h")
+		exercise_driver(module, firmware_id)
+		print(
+			f"CHIRP accepts built identifier '{firmware_id}', display banner "
+			f"'{display_banner}', and memory-layout mutations."
+		)
+		return 0
+	except RuntimeError as error:
+		print(f"check-chirp-compat: {error}", file=sys.stderr)
+		return 1
 
 
 if __name__ == "__main__":
-    main()
+	sys.exit(main())

--- a/ci/chirp.lock.json
+++ b/ci/chirp.lock.json
@@ -1,0 +1,6 @@
+{
+  "commit": "551d835ba26d0b351523afb395d077cbce52d216",
+  "repository": "https://github.com/kk7ds/chirp.git",
+  "track_ref": "refs/heads/master",
+  "upstream_context": "https://github.com/kk7ds/chirp/pull/1414"
+}

--- a/ci/chirp_pin.py
+++ b/ci/chirp_pin.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Validate and update the immutable CHIRP compatibility-test pin."""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_LOCK_PATH = REPOSITORY_ROOT / "ci" / "chirp.lock.json"
+COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+REPOSITORY_PATTERN = re.compile(
+	r"^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\.git$"
+)
+REF_PATTERN = re.compile(r"^refs/(?:heads|tags)/[A-Za-z0-9._/-]+$")
+CONTEXT_PATTERN = re.compile(
+	r"^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/(?:pull|issues)/[0-9]+$"
+)
+REQUIRED_FIELDS = {"commit", "repository", "track_ref", "upstream_context"}
+
+
+class PinError(ValueError):
+	pass
+
+
+def validate_pin(pin: object) -> dict[str, str]:
+	if not isinstance(pin, dict):
+		raise PinError("CHIRP lock must contain a JSON object")
+	if set(pin) != REQUIRED_FIELDS:
+		missing = sorted(REQUIRED_FIELDS - set(pin))
+		extra = sorted(set(pin) - REQUIRED_FIELDS)
+		raise PinError(f"CHIRP lock fields differ (missing={missing}, extra={extra})")
+	if not all(isinstance(value, str) for value in pin.values()):
+		raise PinError("CHIRP lock values must be strings")
+
+	validated = dict(pin)
+	if not COMMIT_PATTERN.fullmatch(validated["commit"]):
+		raise PinError("CHIRP commit must be a full 40-character lowercase SHA")
+	if not REPOSITORY_PATTERN.fullmatch(validated["repository"]):
+		raise PinError("CHIRP repository must be an HTTPS GitHub clone URL")
+	if not REF_PATTERN.fullmatch(validated["track_ref"]):
+		raise PinError("CHIRP tracking ref must be a full heads or tags ref")
+	if ".." in validated["track_ref"] or "//" in validated["track_ref"]:
+		raise PinError("CHIRP tracking ref contains an unsafe path component")
+	if not CONTEXT_PATTERN.fullmatch(validated["upstream_context"]):
+		raise PinError("CHIRP upstream context must be a GitHub issue or pull request URL")
+	return validated
+
+
+def load_pin(path: Path = DEFAULT_LOCK_PATH) -> dict[str, str]:
+	try:
+		pin = json.loads(path.read_text(encoding="utf-8"))
+	except (OSError, json.JSONDecodeError) as error:
+		raise PinError(f"unable to read CHIRP lock {path}: {error}") from error
+	return validate_pin(pin)
+
+
+def update_commit(path: Path, commit: str) -> dict[str, str]:
+	pin = load_pin(path)
+	if not COMMIT_PATTERN.fullmatch(commit):
+		raise PinError("CHIRP commit must be a full 40-character lowercase SHA")
+	pin["commit"] = commit
+	path.write_text(json.dumps(pin, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+	return pin
+
+
+def build_parser() -> argparse.ArgumentParser:
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument("--lock", type=Path, default=DEFAULT_LOCK_PATH)
+	subparsers = parser.add_subparsers(dest="command", required=True)
+	subparsers.add_parser("validate")
+	get_parser = subparsers.add_parser("get")
+	get_parser.add_argument("field", choices=sorted(REQUIRED_FIELDS))
+	update_parser = subparsers.add_parser("update")
+	update_parser.add_argument("commit")
+	return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+	args = build_parser().parse_args(argv)
+	try:
+		if args.command == "update":
+			pin = update_commit(args.lock, args.commit)
+			print(pin["commit"])
+		else:
+			pin = load_pin(args.lock)
+			if args.command == "get":
+				print(pin[args.field])
+			else:
+				print(pin["commit"])
+		return 0
+	except PinError as error:
+		print(f"chirp-pin: {error}", file=sys.stderr)
+		return 1
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/ci/dependencies.md
+++ b/ci/dependencies.md
@@ -28,6 +28,25 @@ the archive. Update the URL, checksum file, and documented versions together.
 GitHub Actions uses Python `3.10.18` and `3.12.11`. Direct and transitive test,
 lint, and formatting packages are pinned in `ci/requirements-ci.txt`.
 
+## CHIRP
+
+Compatibility tests use the upstream `kk7ds/chirp` repository at the exact
+commit recorded in `ci/chirp.lock.json`. CI builds the firmware with the root
+`VERSION_SUFFIX`, extracts the UART programming identifier from the resulting
+binary, and then exercises the pinned UV-K5 driver and EEPROM mutations.
+
+The programming identifier remains `1.02.<VERSION_SUFFIX>` while the EEPROM
+layout is compatible with the upstream UV-K5 driver. The human-facing display
+banner remains `OEFW-<VERSION_SUFFIX>`. If the EEPROM layout diverges, introduce
+a compatibility-major firmware identifier and a dedicated CHIRP subclass,
+referencing https://github.com/kk7ds/chirp/pull/1414 for the upstream design
+history.
+
+The `Update CHIRP pin` workflow checks upstream `master` every Monday and can
+also be run manually. When the tracked commit changes, it updates only the lock
+file and opens a dependency PR so the normal compatibility tests and review are
+required before the new commit becomes the release pin.
+
 ## GitHub Actions
 
 Workflow `uses:` entries are pinned to full commit SHAs with the reviewed

--- a/ci/release_artifacts.py
+++ b/ci/release_artifacts.py
@@ -15,12 +15,14 @@ from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 PACKER_PATH = REPOSITORY_ROOT / "fw-pack.py"
+CHIRP_PIN_MODULE_PATH = REPOSITORY_ROOT / "ci" / "chirp_pin.py"
+CHIRP_PIN_PATH = REPOSITORY_ROOT / "ci" / "chirp.lock.json"
 TAG_PATTERN = re.compile(
 	r"^v(?P<year>[0-9]{2})\.(?P<month>0[1-9]|1[0-2])(?:\.(?P<patch>0|[1-9][0-9]?))?$"
 )
 SUFFIX_PATTERN = re.compile(r"^[A-Z0-9]{7}$")
 BASE36 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-MANIFEST_SCHEMA = 1
+MANIFEST_SCHEMA = 2
 
 
 class ReleaseError(ValueError):
@@ -31,6 +33,15 @@ def _load_packer():
 	spec = importlib.util.spec_from_file_location("firmware_packer", PACKER_PATH)
 	if spec is None or spec.loader is None:
 		raise RuntimeError(f"unable to load firmware packer from {PACKER_PATH}")
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+def _load_chirp_pin_module():
+	spec = importlib.util.spec_from_file_location("chirp_pin_for_release", CHIRP_PIN_MODULE_PATH)
+	if spec is None or spec.loader is None:
+		raise RuntimeError(f"unable to load CHIRP pin helper from {CHIRP_PIN_MODULE_PATH}")
 	module = importlib.util.module_from_spec(spec)
 	spec.loader.exec_module(module)
 	return module
@@ -132,6 +143,9 @@ def bundle_artifacts(
 		"schema": MANIFEST_SCHEMA,
 		"release_tag": release_tag,
 		"source_commit": source_commit,
+		"compatibility": {
+			"chirp": _load_chirp_pin_module().load_pin(CHIRP_PIN_PATH),
+		},
 		"build_environment": {
 			"container_base": os.environ.get("BUILD_CONTAINER_BASE", "unavailable"),
 			"package_snapshot": os.environ.get("BUILD_PACKAGE_SNAPSHOT", "unavailable"),
@@ -176,6 +190,10 @@ def verify_bundle(manifest_path: Path, expected_suffix: str, expected_tag: str |
 		raise ReleaseError("release manifest tag does not match the expected tag")
 	if expected_tag is not None and tag_to_suffix(expected_tag) != expected_suffix:
 		raise ReleaseError("expected release tag and suffix do not match")
+	try:
+		_load_chirp_pin_module().validate_pin(manifest.get("compatibility", {}).get("chirp"))
+	except ValueError as error:
+		raise ReleaseError(f"release manifest has invalid CHIRP compatibility metadata: {error}") from error
 
 	for filename, metadata in manifest.get("files", {}).items():
 		path = manifest_path.parent / filename

--- a/tests/test_build_inputs.py
+++ b/tests/test_build_inputs.py
@@ -90,6 +90,7 @@ def test_ci_suffixes_and_chirp_source_do_not_drift():
 	assert "REQUESTED_SUFFIX" not in main_workflow
 	assert 'SUFFIX="CI${' not in main_workflow
 	assert main_workflow.count("submodules: recursive") >= 2
+	assert 'TARGET=loaner-firmware VERSION_SUFFIX="${VERSION_SUFFIX}"' in main_workflow
 	assert "VERSION_SUFFIX: LNR" not in codeql_workflow
 	assert "< VERSION_SUFFIX" in main_workflow
 	assert "< VERSION_SUFFIX" in codeql_workflow

--- a/tests/test_build_inputs.py
+++ b/tests/test_build_inputs.py
@@ -89,6 +89,7 @@ def test_ci_suffixes_and_chirp_source_do_not_drift():
 	assert "COMPAT_SUFFIX" not in main_workflow
 	assert "REQUESTED_SUFFIX" not in main_workflow
 	assert 'SUFFIX="CI${' not in main_workflow
+	assert main_workflow.count("submodules: recursive") >= 2
 	assert "VERSION_SUFFIX: LNR" not in codeql_workflow
 	assert "< VERSION_SUFFIX" in main_workflow
 	assert "< VERSION_SUFFIX" in codeql_workflow

--- a/tests/test_build_inputs.py
+++ b/tests/test_build_inputs.py
@@ -76,3 +76,19 @@ def test_full_pipeline_requires_two_identical_builds():
 		'cmp "${FIRST_BUILD}/loaner-firmware.packed.bin" loaner-firmware.packed.bin'
 		in repro_script
 	)
+
+
+def test_ci_suffixes_and_chirp_source_do_not_drift():
+	main_workflow = (ROOT / ".github" / "workflows" / "main.yaml").read_text(encoding="utf-8")
+	codeql_workflow = (ROOT / ".github" / "workflows" / "codeql.yaml").read_text(
+		encoding="utf-8"
+	)
+
+	assert "aditaa/chirp" not in main_workflow
+	assert "loaner-firmware-whitelist" not in main_workflow
+	assert "COMPAT_SUFFIX" not in main_workflow
+	assert "REQUESTED_SUFFIX" not in main_workflow
+	assert 'SUFFIX="CI${' not in main_workflow
+	assert "VERSION_SUFFIX: LNR" not in codeql_workflow
+	assert "< VERSION_SUFFIX" in main_workflow
+	assert "< VERSION_SUFFIX" in codeql_workflow

--- a/tests/test_chirp_compat.py
+++ b/tests/test_chirp_compat.py
@@ -1,0 +1,44 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_module(name, path):
+	spec = importlib.util.spec_from_file_location(name, Path(path))
+	assert spec is not None
+	assert spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+COMPAT = _load_module("check_chirp_compat", "ci/check-chirp-compat.py")
+
+
+def test_extracts_actual_firmware_ids_from_built_image(tmp_path):
+	binary = tmp_path / "firmware.bin"
+	binary.write_bytes(
+		b"prefix\x00OEFW-LNR24A5\x00middle\x001.02.LNR24A5\x00suffix"
+	)
+
+	assert COMPAT.extract_firmware_ids(binary, "LNR24A5") == (
+		"1.02.LNR24A5",
+		"OEFW-LNR24A5",
+	)
+
+
+def test_rejects_firmware_id_from_a_different_build(tmp_path):
+	binary = tmp_path / "firmware.bin"
+	binary.write_bytes(b"OEFW-LNR24A4\x001.02.LNR24A4\x00")
+
+	with pytest.raises(RuntimeError, match="expected 1.02.LNR24A5"):
+		COMPAT.extract_firmware_ids(binary, "LNR24A5")
+
+
+def test_rejects_missing_programming_identifier(tmp_path):
+	binary = tmp_path / "firmware.bin"
+	binary.write_bytes(b"OEFW-LNR24A5\x00")
+
+	with pytest.raises(RuntimeError, match="UART programming identifier"):
+		COMPAT.extract_firmware_ids(binary, "LNR24A5")

--- a/tests/test_chirp_pin.py
+++ b/tests/test_chirp_pin.py
@@ -1,0 +1,46 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _load_module(name, path):
+	spec = importlib.util.spec_from_file_location(name, Path(path))
+	assert spec is not None
+	assert spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+PIN = _load_module("chirp_pin", "ci/chirp_pin.py")
+
+
+def test_committed_pin_is_immutable_upstream_chirp():
+	pin = PIN.load_pin()
+
+	assert pin["repository"] == "https://github.com/kk7ds/chirp.git"
+	assert PIN.COMMIT_PATTERN.fullmatch(pin["commit"])
+	assert pin["track_ref"] == "refs/heads/master"
+	assert pin["upstream_context"] == "https://github.com/kk7ds/chirp/pull/1414"
+
+
+def test_update_changes_only_commit(tmp_path):
+	lock = tmp_path / "chirp.lock.json"
+	original = PIN.load_pin()
+	lock.write_text(json.dumps(original), encoding="utf-8")
+
+	updated = PIN.update_commit(lock, "a" * 40)
+
+	assert updated == {**original, "commit": "a" * 40}
+	assert PIN.load_pin(lock) == updated
+
+
+@pytest.mark.parametrize("commit", ["main", "A" * 40, "a" * 39])
+def test_update_rejects_mutable_or_invalid_commit(tmp_path, commit):
+	lock = tmp_path / "chirp.lock.json"
+	lock.write_text(Path("ci/chirp.lock.json").read_text(encoding="utf-8"), encoding="utf-8")
+
+	with pytest.raises(PIN.PinError, match="full 40-character"):
+		PIN.update_commit(lock, commit)

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -72,6 +72,9 @@ def test_release_bundle_records_and_verifies_integrity(tmp_path):
 	assert manifest["build_environment"]["package_snapshot"]
 	assert manifest["build_environment"]["source_date_epoch"]
 	assert manifest["firmware_ids"]["uart_handshake"] == "1.02.LNR24A5"
+	assert manifest["compatibility"]["chirp"] == json.loads(
+		Path("ci/chirp.lock.json").read_text(encoding="utf-8")
+	)
 	assert manifest["files"]["loaner-firmware-LNR24A5.bin"]["size"] == 0x2200
 	assert (output_dir / "loaner-firmware-LNR24A5.sha256").is_file()
 


### PR DESCRIPTION
## Summary
- follow the compatibility decision from kk7ds/chirp#1414 by testing the regular upstream UV-K5 driver instead of the closed custom whitelist branch
- derive all CI firmware suffixes from the root `VERSION_SUFFIX` and validate the identifier extracted from the actual compiled binary
- pin CHIRP to an immutable reviewed commit and record that commit in every release manifest
- add a scheduled/manual workflow that opens a dependency PR and dispatches compatibility CI when upstream CHIRP moves
- correct the operator documentation to use the regular Quansheng UV-K5 model

## Validation
- 107 firmware tests passed in the pinned deterministic container
- two raw and packed builds were byte-identical
- pinned upstream CHIRP UV-K5 suite: 102 passed, 24 skipped, 3 xfailed, 3 xpassed
- pinned driver accepted the newly built `1.02.LNR2415` identifier and completed EEPROM mutation checks
- Ruff, actionlint, ShellCheck, and `git diff --check` passed

Closes #44

Upstream design history: https://github.com/kk7ds/chirp/pull/1414