### PR TITLE
Build reusable firmware host-test harness

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -141,6 +141,9 @@ jobs:
         run: python -m pip install --disable-pip-version-check -r ci/requirements-ci.txt
 
       - name: Run pytest
+        env:
+          HOST_TESTS_REQUIRED: "1"
+          HOST_SANITIZERS: address,undefined
         run: pytest -q
 
   build:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -57,6 +57,10 @@ VERSION_SUFFIX=LNR2415 ci/run.sh
 
 GitHub Actions runs tests under Python 3.10.18 and 3.12.11, checks CHIRP compatibility, runs CodeQL, and performs the Docker firmware build. Docker builds export the changed-line formatting diff on the host and mount it read-only, so Git history never enters the image context. Keep the firmware below `MAX_FIRMWARE_SIZE` (122880 bytes by default).
 
+See `docs/host-testing.md` for the pure-logic/hardware boundary, reusable fake
+platform adapters, sanitizer mode, and the command for running one host C test
+module.
+
 ## Release Version Mapping
 
 Release tags must use `vYY.MM[.PATCH]`. They map to the seven-character suffix `LNRYYMP`, where month and patch each use one base-36 digit (`0-9`, then `A-Z`):

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -75,7 +75,7 @@ echo "Checking C formatting..."
 run_cppcheck
 
 echo "Running unit tests..."
-pytest -q
+HOST_TESTS_REQUIRED=1 HOST_SANITIZERS=address,undefined pytest -q
 
 echo "Build inputs:"
 echo "  source commit: ${SOURCE_COMMIT}"

--- a/docs/host-testing.md
+++ b/docs/host-testing.md
@@ -1,0 +1,47 @@
+# Firmware host testing
+
+Host tests exercise firmware logic without an ARM board. They complement, but
+do not replace, release smoke tests on a radio.
+
+## Test boundary
+
+Pure modules accept ordinary values and buffers and must not read MCU registers
+directly. Examples include frequency policy, EEPROM value validation, firmware
+packing, and UART frame validation. These modules can be compiled with the host
+C compiler and tested directly.
+
+Hardware drivers under `driver/`, board initialization in `board.c`, and radio
+state transitions that control the PA remain hardware-facing. When logic needs
+one of those services, keep the decision logic separate and represent EEPROM,
+register, time, and GPIO access through a small adapter. Reusable fake adapters
+for those four resources live in `tests/host/fake_platform.*` and include
+explicit read/write failure injection.
+
+## Running tests
+
+Run the full suite with:
+
+```sh
+pytest -q
+```
+
+Run one host module while developing with:
+
+```sh
+pytest -q tests/test_uart_protocol.py
+```
+
+Linux CI requires a host compiler and enables AddressSanitizer and
+UndefinedBehaviorSanitizer for host executables. To reproduce that mode:
+
+```sh
+HOST_TESTS_REQUIRED=1 HOST_SANITIZERS=address,undefined pytest -q
+```
+
+## Hardware release checks
+
+Before a release, separately record the exact firmware artifact and perform the
+boot, channel-selection, receive-audio, PTT, timeout-timer, power-cycle, CHIRP
+download/upload, battery, and RF bench checks required by the release issues.
+Host tests cannot validate RF purity, PA shutdown timing, peripheral electrical
+behavior, charging, or board-specific calibration.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Host-side firmware tests and reusable test support."""

--- a/tests/host/fake_platform.c
+++ b/tests/host/fake_platform.c
@@ -1,0 +1,66 @@
+#include <string.h>
+
+#include "tests/host/fake_platform.h"
+
+void HOST_FakePlatform_Reset(HOST_FakePlatform_t *pPlatform)
+{
+	memset(pPlatform, 0, sizeof(*pPlatform));
+}
+
+bool HOST_FakeEeprom_Read(HOST_FakePlatform_t *pPlatform, uint16_t Address, void *pData, size_t Size)
+{
+	if (pPlatform->FailEepromRead || Address > HOST_FAKE_EEPROM_SIZE || Size > HOST_FAKE_EEPROM_SIZE - Address) {
+		return false;
+	}
+	memcpy(pData, &pPlatform->Eeprom[Address], Size);
+	return true;
+}
+
+bool HOST_FakeEeprom_Write(HOST_FakePlatform_t *pPlatform, uint16_t Address, const void *pData, size_t Size)
+{
+	if (pPlatform->FailEepromWrite || Address > HOST_FAKE_EEPROM_SIZE || Size > HOST_FAKE_EEPROM_SIZE - Address) {
+		return false;
+	}
+	memcpy(&pPlatform->Eeprom[Address], pData, Size);
+	return true;
+}
+
+bool HOST_FakeRegister_Read(HOST_FakePlatform_t *pPlatform, uint8_t Address, uint16_t *pValue)
+{
+	if (pPlatform->FailRegisterRead || Address >= HOST_FAKE_REGISTER_COUNT) {
+		return false;
+	}
+	*pValue = pPlatform->Registers[Address];
+	return true;
+}
+
+bool HOST_FakeRegister_Write(HOST_FakePlatform_t *pPlatform, uint8_t Address, uint16_t Value)
+{
+	if (pPlatform->FailRegisterWrite || Address >= HOST_FAKE_REGISTER_COUNT) {
+		return false;
+	}
+	pPlatform->Registers[Address] = Value;
+	return true;
+}
+
+uint32_t HOST_FakeTime_Get(const HOST_FakePlatform_t *pPlatform)
+{
+	return pPlatform->Time;
+}
+
+void HOST_FakeTime_Advance(HOST_FakePlatform_t *pPlatform, uint32_t Ticks)
+{
+	pPlatform->Time += Ticks;
+}
+
+bool HOST_FakeGpio_Get(const HOST_FakePlatform_t *pPlatform, uint8_t Pin)
+{
+	return Pin < HOST_FAKE_GPIO_COUNT && pPlatform->Gpio[Pin];
+}
+
+void HOST_FakeGpio_Set(HOST_FakePlatform_t *pPlatform, uint8_t Pin, bool Set)
+{
+	if (Pin < HOST_FAKE_GPIO_COUNT) {
+		pPlatform->Gpio[Pin] = Set;
+	}
+}

--- a/tests/host/fake_platform.h
+++ b/tests/host/fake_platform.h
@@ -1,0 +1,34 @@
+#ifndef TESTS_HOST_FAKE_PLATFORM_H
+#define TESTS_HOST_FAKE_PLATFORM_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define HOST_FAKE_EEPROM_SIZE 0x2000U
+#define HOST_FAKE_REGISTER_COUNT 128U
+#define HOST_FAKE_GPIO_COUNT 32U
+
+typedef struct
+{
+	uint8_t Eeprom[HOST_FAKE_EEPROM_SIZE];
+	uint16_t Registers[HOST_FAKE_REGISTER_COUNT];
+	bool Gpio[HOST_FAKE_GPIO_COUNT];
+	uint32_t Time;
+	bool FailEepromRead;
+	bool FailEepromWrite;
+	bool FailRegisterRead;
+	bool FailRegisterWrite;
+} HOST_FakePlatform_t;
+
+void HOST_FakePlatform_Reset(HOST_FakePlatform_t *pPlatform);
+bool HOST_FakeEeprom_Read(HOST_FakePlatform_t *pPlatform, uint16_t Address, void *pData, size_t Size);
+bool HOST_FakeEeprom_Write(HOST_FakePlatform_t *pPlatform, uint16_t Address, const void *pData, size_t Size);
+bool HOST_FakeRegister_Read(HOST_FakePlatform_t *pPlatform, uint8_t Address, uint16_t *pValue);
+bool HOST_FakeRegister_Write(HOST_FakePlatform_t *pPlatform, uint8_t Address, uint16_t Value);
+uint32_t HOST_FakeTime_Get(const HOST_FakePlatform_t *pPlatform);
+void HOST_FakeTime_Advance(HOST_FakePlatform_t *pPlatform, uint32_t Ticks);
+bool HOST_FakeGpio_Get(const HOST_FakePlatform_t *pPlatform, uint8_t Pin);
+void HOST_FakeGpio_Set(HOST_FakePlatform_t *pPlatform, uint8_t Pin, bool Set);
+
+#endif

--- a/tests/host/fake_platform_harness.c
+++ b/tests/host/fake_platform_harness.c
@@ -1,0 +1,39 @@
+#include <stdint.h>
+#include <string.h>
+
+#include "tests/host/fake_platform.h"
+
+int main(void)
+{
+	HOST_FakePlatform_t Platform;
+	const uint8_t Written[]	      = { 1U, 2U, 3U, 4U };
+	uint8_t Read[sizeof(Written)] = { 0 };
+	uint16_t Register;
+
+	HOST_FakePlatform_Reset(&Platform);
+	if (!HOST_FakeEeprom_Write(&Platform, 0x100U, Written, sizeof(Written))) {
+		return 1;
+	}
+	if (!HOST_FakeEeprom_Read(&Platform, 0x100U, Read, sizeof(Read)) || memcmp(Written, Read, sizeof(Read)) != 0) {
+		return 2;
+	}
+	if (HOST_FakeEeprom_Read(&Platform, HOST_FAKE_EEPROM_SIZE - 1U, Read, sizeof(Read))) {
+		return 3;
+	}
+	Platform.FailEepromRead = true;
+	if (HOST_FakeEeprom_Read(&Platform, 0x100U, Read, sizeof(Read))) {
+		return 4;
+	}
+	if (!HOST_FakeRegister_Write(&Platform, 0x20U, 0xA55AU) || !HOST_FakeRegister_Read(&Platform, 0x20U, &Register) || Register != 0xA55AU) {
+		return 5;
+	}
+	HOST_FakeTime_Advance(&Platform, 25U);
+	if (HOST_FakeTime_Get(&Platform) != 25U) {
+		return 6;
+	}
+	HOST_FakeGpio_Set(&Platform, 7U, true);
+	if (!HOST_FakeGpio_Get(&Platform, 7U) || HOST_FakeGpio_Get(&Platform, HOST_FAKE_GPIO_COUNT)) {
+		return 7;
+	}
+	return 0;
+}

--- a/tests/host_tools.py
+++ b/tests/host_tools.py
@@ -1,0 +1,78 @@
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def host_compiler() -> str:
+	requested = os.environ.get("CC")
+	candidates = [requested] if requested else ["cc", "gcc", "clang"]
+	for candidate in candidates:
+		if candidate and (compiler := shutil.which(candidate)):
+			return compiler
+
+	message = "A host C compiler is required for firmware host tests"
+	if os.environ.get("HOST_TESTS_REQUIRED") == "1":
+		pytest.fail(message)
+	pytest.skip(message)
+
+
+def sanitizer_flags(*, shared: bool) -> list[str]:
+	if sys.platform == "win32":
+		return []
+
+	requested = [
+		name.strip()
+		for name in os.environ.get("HOST_SANITIZERS", "").split(",")
+		if name.strip()
+	]
+	if shared:
+		requested = [name for name in requested if name != "address"]
+	if not requested:
+		return []
+	return [f"-fsanitize={','.join(requested)}", "-fno-omit-frame-pointer"]
+
+
+def compile_c(
+	*,
+	output: Path,
+	sources: Iterable[Path],
+	include_dirs: Iterable[Path] = (ROOT,),
+	shared: bool = False,
+) -> Path:
+	flags = ["-std=c11", "-Wall", "-Wextra", "-Werror", "-g"]
+	flags.extend(sanitizer_flags(shared=shared))
+	if shared:
+		flags.append("-shared")
+		if sys.platform != "win32":
+			flags.append("-fPIC")
+
+	command = [host_compiler(), *flags]
+	for include_dir in include_dirs:
+		command.extend(["-I", str(include_dir)])
+	command.extend(str(source) for source in sources)
+	command.extend(["-o", str(output)])
+	subprocess.run(command, check=True)
+	return output
+
+
+def shared_library_path(directory: Path, stem: str) -> Path:
+	if sys.platform == "win32":
+		return directory / f"{stem}.dll"
+	if sys.platform == "darwin":
+		return directory / f"lib{stem}.dylib"
+	return directory / f"lib{stem}.so"
+
+
+def host_runtime_environment() -> dict[str, str]:
+	environment = os.environ.copy()
+	environment.setdefault("ASAN_OPTIONS", "detect_leaks=0:halt_on_error=1")
+	environment.setdefault("UBSAN_OPTIONS", "halt_on_error=1:print_stacktrace=1")
+	return environment

--- a/tests/test_eeprom_validation.py
+++ b/tests/test_eeprom_validation.py
@@ -1,10 +1,8 @@
 import ctypes
-import shutil
-import subprocess
-import sys
-from pathlib import Path
 
 import pytest
+
+from tests.host_tools import ROOT, compile_c, shared_library_path
 
 
 BATTERY_FALLBACK = [1258, 1747, 1876, 1901, 2004, 2300]
@@ -14,29 +12,13 @@ PA_FALLBACK = [0, 0, 0]
 
 @pytest.fixture(scope="session")
 def validation_library(tmp_path_factory):
-    compiler = shutil.which("gcc")
-    if compiler is None:
-        pytest.skip("gcc is required for the EEPROM validation host tests")
-
-    repo_root = Path(__file__).resolve().parents[1]
     output_dir = tmp_path_factory.mktemp("eeprom-validation")
-    library = output_dir / ("eeprom_validation.dll" if sys.platform == "win32" else "libeeprom_validation.so")
-    command = [
-        compiler,
-        "-shared",
-        "-std=c11",
-        "-Wall",
-        "-Wextra",
-        "-Werror",
-        "-I",
-        str(repo_root),
-        str(repo_root / "eeprom_validation.c"),
-        "-o",
-        str(library),
-    ]
-    if sys.platform != "win32":
-        command.insert(2, "-fPIC")
-    subprocess.run(command, check=True)
+    library = shared_library_path(output_dir, "eeprom_validation")
+    compile_c(
+        output=library,
+        sources=[ROOT / "eeprom_validation.c"],
+        shared=True,
+    )
 
     loaded = ctypes.CDLL(str(library))
     loaded.EEPROM_ValidateU8.argtypes = [ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]

--- a/tests/test_frequency_policy.py
+++ b/tests/test_frequency_policy.py
@@ -1,20 +1,14 @@
-import shutil
 import subprocess
 import textwrap
-from pathlib import Path
 
 import pytest
 
+from tests.host_tools import ROOT, compile_c, host_runtime_environment
 
-ROOT = Path(__file__).resolve().parents[1]
 
 
 @pytest.fixture(scope="module")
 def frequency_policy_binary(tmp_path_factory):
-    compiler = shutil.which("cc") or shutil.which("gcc")
-    if compiler is None:
-        pytest.skip("A host C compiler is required for the frequency policy test")
-
     build_dir = tmp_path_factory.mktemp("frequency-policy")
     harness = build_dir / "frequency_policy_harness.c"
     executable = build_dir / "frequency_policy_harness"
@@ -54,22 +48,10 @@ def frequency_policy_binary(tmp_path_factory):
         ),
         encoding="utf-8",
     )
-    subprocess.run(
-        [
-            compiler,
-            "-std=c11",
-            "-Wall",
-            "-Werror",
-            "-I",
-            str(ROOT),
-            str(ROOT / "frequencies.c"),
-            str(harness),
-            "-o",
-            str(executable),
-        ],
-        check=True,
+    return compile_c(
+        output=executable,
+        sources=[ROOT / "frequencies.c", harness],
     )
-    return executable
 
 
 def run_policy(executable, frequency, channel=0):
@@ -78,6 +60,7 @@ def run_policy(executable, frequency, channel=0):
         check=True,
         capture_output=True,
         text=True,
+        env=host_runtime_environment(),
     )
     supported, check_result = result.stdout.split()
     return supported == "1", int(check_result)

--- a/tests/test_host_platform.py
+++ b/tests/test_host_platform.py
@@ -1,0 +1,25 @@
+import subprocess
+
+import pytest
+
+from tests.host_tools import ROOT, compile_c, host_runtime_environment
+
+
+@pytest.fixture(scope="session")
+def fake_platform_harness(tmp_path_factory):
+	output = tmp_path_factory.mktemp("fake-platform") / "fake_platform_harness"
+	return compile_c(
+		output=output,
+		sources=[
+			ROOT / "tests" / "host" / "fake_platform_harness.c",
+			ROOT / "tests" / "host" / "fake_platform.c",
+		],
+	)
+
+
+def test_fake_platform_adapters(fake_platform_harness):
+	subprocess.run(
+		[str(fake_platform_harness)],
+		check=True,
+		env=host_runtime_environment(),
+	)

--- a/tests/test_uart_protocol.py
+++ b/tests/test_uart_protocol.py
@@ -1,11 +1,11 @@
-import shutil
 import struct
 import subprocess
 from binascii import crc_hqx
 from itertools import cycle
-from pathlib import Path
 
 import pytest
+
+from tests.host_tools import ROOT, compile_c, host_runtime_environment
 
 
 OBFUSCATION = bytes(
@@ -60,29 +60,11 @@ def frame(payload, encrypted=True, corrupt_crc=False):
 
 @pytest.fixture(scope="session")
 def uart_harness(tmp_path_factory):
-    compiler = shutil.which("gcc")
-    if compiler is None:
-        pytest.skip("gcc is required for UART protocol host tests")
-
     executable = tmp_path_factory.mktemp("uart_protocol") / "uart_protocol_harness"
-    root = Path(__file__).resolve().parents[1]
-    subprocess.run(
-        [
-            compiler,
-            "-std=c11",
-            "-Wall",
-            "-Wextra",
-            "-Werror",
-            "-I",
-            str(root),
-            str(root / "tests" / "uart_protocol_harness.c"),
-            str(root / "app" / "uart_protocol.c"),
-            "-o",
-            str(executable),
-        ],
-        check=True,
+    return compile_c(
+        output=executable,
+        sources=[ROOT / "tests" / "uart_protocol_harness.c", ROOT / "app" / "uart_protocol.c"],
     )
-    return executable
 
 
 def validate(uart_harness, payload):
@@ -91,6 +73,7 @@ def validate(uart_harness, payload):
         check=True,
         capture_output=True,
         text=True,
+        env=host_runtime_environment(),
     )
     return result.stdout.strip() == "1"
 
@@ -108,6 +91,7 @@ def parse(uart_harness, packet, ring_size=256, start=0, encrypted=True):
         check=True,
         capture_output=True,
         text=True,
+        env=host_runtime_environment(),
     )
     frame_result, next_index, command_size, next_encrypted, command_id = result.stdout.split()
     return {


### PR DESCRIPTION
## Summary
- consolidate host C compilation and sanitizer configuration in one reusable test helper
- add reusable EEPROM, register, time, and GPIO fakes with bounds checks and failure injection
- require a host compiler in Linux CI and run host executables with AddressSanitizer and UndefinedBehaviorSanitizer
- refactor the frequency, EEPROM-validation, and UART tests onto the common harness
- document the pure-logic/hardware boundary, single-module commands, sanitizer mode, and separate hardware release checks

## Impact
This does not change the firmware binary. It creates the test foundation needed to implement and fault-inject the peripheral timeout work in #40.

## Validation
- Linux container: 108 passed with `HOST_TESTS_REQUIRED=1 HOST_SANITIZERS=address,undefined`
- full deterministic Docker pipeline passed
- raw and packed firmware remained byte-identical to `main`
- Ruff, actionlint, formatting, cppcheck, and `git diff --check` passed

Closes #39