### PR TITLE
Add bounded peripheral timeout recovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ ifeq ($(ENABLE_OVERLAY),1)
 OBJS += driver/flash.o
 endif
 OBJS += driver/gpio.o
+OBJS += driver/hardware.o
 OBJS += driver/i2c.o
 OBJS += driver/keyboard.o
 OBJS += driver/spi.o

--- a/app/app.c
+++ b/app/app.c
@@ -41,6 +41,7 @@
 #endif
 #include "driver/bk4819.h"
 #include "driver/gpio.h"
+#include "driver/hardware.h"
 #include "driver/keyboard.h"
 #include "driver/st7565.h"
 #include "driver/system.h"
@@ -500,15 +501,21 @@ static void DUALWATCH_Alternate(void)
 		gDualWatchCountdown = 10;
 }
 
-void APP_CheckRadioInterrupts(void)
+static bool APP_CheckRadioInterrupts(void)
 {
+	uint8_t PollLimit = 64U;
+
 	if (gScreenToDisplay == DISPLAY_SCANNER) {
-		return;
+		return true;
 	}
 
 	while (BK4819_ReadRegister(BK4819_REG_0C) & 1U) {
 		uint16_t Mask;
 
+		if (PollLimit-- == 0U) {
+			HARDWARE_ReportFault(HARDWARE_FAULT_BK4819);
+			return false;
+		}
 		BK4819_WriteRegister(BK4819_REG_02, 0);
 		Mask = BK4819_ReadRegister(BK4819_REG_02);
 		if (Mask & BK4819_REG_02_DTMF_5TONE_FOUND) {
@@ -579,6 +586,7 @@ void APP_CheckRadioInterrupts(void)
 		}
 #endif
 	}
+	return true;
 }
 
 void APP_EndTransmission(void)
@@ -642,6 +650,15 @@ static void APP_HandleVox(void)
 
 void APP_Update(void)
 {
+	const HARDWARE_Fault_t HardwareFault = HARDWARE_TakePendingFault();
+
+	if (HardwareFault != HARDWARE_FAULT_NONE) {
+		RADIO_ForceSafeState();
+		GUI_SelectNextDisplay(DISPLAY_MAIN);
+		gUpdateStatus  = HardwareFault != HARDWARE_FAULT_SPI;
+		gUpdateDisplay = HardwareFault != HARDWARE_FAULT_SPI;
+	}
+
 	if (gFlagPlayQueuedVoice) {
 		AUDIO_PlayQueuedVoice();
 		gFlagPlayQueuedVoice = false;
@@ -1659,4 +1676,3 @@ Skip:
 	GUI_SelectNextDisplay(gRequestDisplayScreen);
 	gRequestDisplayScreen = DISPLAY_INVALID;
 }
-

--- a/app/uart.c
+++ b/app/uart.c
@@ -170,7 +170,7 @@ static uint16_t gUART_WriteIndex;
 static uint16_t UART_CommandSize;
 static bool bIsEncrypted = true;
 
-static void SendReply(void *pReply, uint16_t Size)
+static bool SendReply(void *pReply, uint16_t Size)
 {
 	Header_t Header;
 	Footer_t Footer;
@@ -186,8 +186,9 @@ static void SendReply(void *pReply, uint16_t Size)
 
 	Header.ID = 0xCDAB;
 	Header.Size = Size;
-	UART_Send(&Header, sizeof(Header));
-	UART_Send(pReply, Size);
+	if (!UART_Send(&Header, sizeof(Header)) || !UART_Send(pReply, Size)) {
+		return false;
+	}
 	if (bIsEncrypted) {
 		Footer.Padding[0] = Obfuscation[(Size + 0) % 16] ^ 0xFF;
 		Footer.Padding[1] = Obfuscation[(Size + 1) % 16] ^ 0xFF;
@@ -197,7 +198,7 @@ static void SendReply(void *pReply, uint16_t Size)
 	}
 	Footer.ID = 0xBADC;
 
-	UART_Send(&Footer, sizeof(Footer));
+	return UART_Send(&Footer, sizeof(Footer));
 }
 
 static void SendVersion(void)
@@ -226,7 +227,9 @@ static bool IsBadChallenge(const uint32_t *pKey, const uint32_t *pIn, const uint
 	IV[1] = 0;
 	IV[2] = 0;
 	IV[3] = 0;
-	AES_Encrypt(pKey, IV, pIn, IV, true);
+	if (!AES_Encrypt(pKey, IV, pIn, IV, true)) {
+		return true;
+	}
 	for (i = 0; i < 4; i++) {
 		if (IV[i] != pResponse[i]) {
 			return true;
@@ -271,7 +274,9 @@ static void CMD_051B(const uint8_t *pBuffer)
 	}
 
 	if (!bLocked) {
-		EEPROM_ReadBuffer(pCmd->Offset, Reply.Data.Data, pCmd->Size);
+		if (!EEPROM_ReadBuffer(pCmd->Offset, Reply.Data.Data, pCmd->Size)) {
+			return;
+		}
 	}
 
 	SendReply(&Reply, pCmd->Size + 8);
@@ -315,7 +320,9 @@ static void CMD_051D(const uint8_t *pBuffer)
 			}
 
 			if ((Offset < 0x0E98 || Offset >= 0x0EA0) || !bIsInLockScreen || pCmd->bAllowPassword) {
-				EEPROM_WriteBuffer(Offset, &pCmd->Data[i * 8U]);
+				if (!EEPROM_WriteBuffer(Offset, &pCmd->Data[i * 8U])) {
+					return;
+				}
 			}
 		}
 
@@ -347,7 +354,9 @@ static void CMD_0529(void)
 	Reply.Header.ID = 0x52A;
 	Reply.Header.Size = sizeof(Reply.Data);
 	// Original doesn't actually send current!
-	BOARD_ADC_GetBatteryInfo(&Reply.Data.Voltage, &Reply.Data.Current);
+	if (!BOARD_ADC_GetBatteryInfo(&Reply.Data.Voltage, &Reply.Data.Current)) {
+		return;
+	}
 	SendReply(&Reply, sizeof(Reply));
 }
 

--- a/board.c
+++ b/board.c
@@ -34,6 +34,7 @@
 #include "driver/eeprom.h"
 #include "driver/flash.h"
 #include "driver/gpio.h"
+#include "driver/hardware.h"
 #include "driver/system.h"
 #include "driver/st7565.h"
 #include "eeprom_validation.h"
@@ -48,12 +49,13 @@
 #if defined(ENABLE_OVERLAY)
 void BOARD_FLASH_Init(void)
 {
-	FLASH_Init(FLASH_READ_MODE_1_CYCLE);
-	FLASH_ConfigureTrimValues();
+	if (!FLASH_Init(FLASH_READ_MODE_1_CYCLE) || !FLASH_ConfigureTrimValues()) {
+		return;
+	}
 	SYSTEM_ConfigureClocks();
 	overlay_FLASH_MainClock = 48000000;
 	overlay_FLASH_ClockMultiplier = 48;
-	FLASH_Init(FLASH_READ_MODE_2_CYCLE);
+	(void)FLASH_Init(FLASH_READ_MODE_2_CYCLE);
 }
 #endif
 
@@ -483,14 +485,22 @@ void BOARD_ADC_Init(void)
 	ADC_SoftReset();
 }
 
-void BOARD_ADC_GetBatteryInfo(uint16_t *pVoltage, uint16_t *pCurrent)
+bool BOARD_ADC_GetBatteryInfo(uint16_t *pVoltage, uint16_t *pCurrent)
 {
+	uint32_t Timeout = 100000U;
+
 	ADC_Start();
 
 	while (!ADC_CheckEndOfConversion(ADC_CH9)) {
+		if (Timeout-- == 0U) {
+			ADC_SoftReset();
+			HARDWARE_ReportFault(HARDWARE_FAULT_ADC);
+			return false;
+		}
 	}
 	*pVoltage = ADC_GetValue(ADC_CH4);
 	*pCurrent = ADC_GetValue(ADC_CH9);
+	return true;
 }
 
 void BOARD_Init(void)

--- a/board.h
+++ b/board.h
@@ -24,11 +24,10 @@ void BOARD_FLASH_Init(void);
 void BOARD_GPIO_Init(void);
 void BOARD_PORTCON_Init(void);
 void BOARD_ADC_Init(void);
-void BOARD_ADC_GetBatteryInfo(uint16_t *pVoltage, uint16_t *pCurrent);
+bool BOARD_ADC_GetBatteryInfo(uint16_t *pVoltage, uint16_t *pCurrent);
 void BOARD_Init(void);
 void BOARD_EEPROM_Init(void);
 void BOARD_EEPROM_LoadCalibration(void);
 void BOARD_FactoryReset(bool bIsAll);
 
 #endif
-

--- a/docs/peripheral-timeouts.md
+++ b/docs/peripheral-timeouts.md
@@ -1,0 +1,45 @@
+# Peripheral timeout and recovery policy
+
+Firmware code must not wait forever for a peripheral. A timeout records the
+failing subsystem, returns failure through the driver API, and is consumed by
+the foreground loop. The recovery path disables the BK4819 TX DSP, PA bias,
+PA-enable GPIO, red TX LED, speaker path, and future TX attempts. When the LCD
+is usable, the main screen displays the failing subsystem and the radio remains
+receive-only until it is rebooted.
+
+## Polling inventory
+
+| Path | Bound | Failure behavior |
+| --- | ---: | --- |
+| ADC battery conversion | 100,000 polls | Soft-reset ADC; preserve the previous reading |
+| AES block completion | 100,000 polls | Disable AES; reject the UART challenge |
+| UART TX FIFO | 100,000 polls per byte | Clear the TX FIFO; abort the reply |
+| LCD SPI FIFO / TX active | 100,000 polls | Abort the current display operation |
+| BK4819 interrupt drain | 64 events per foreground pass | Latch radio fault and force TX-safe state |
+| BK4819 setup interrupt clear | 100 ms | Abort setup and force TX-safe state |
+| BK4819 air-copy TX | 200 polls at 5 ms | Reset FSK and latch radio fault |
+| EEPROM I2C ACK | 255 polls per byte | Stop the bus; reads return erased `0xFF` defaults and writes fail |
+| Optional flash busy / wake | 1,000,000 polls | Abort the overlay operation and return failure |
+
+The poll counts are deliberately generous CPU-iteration limits. The BK4819
+paths use existing millisecond delays and therefore have explicit wall-clock
+bounds. Hardware release testing must confirm that normal operations never
+approach these limits and that firmware size remains within the configured CI
+limit.
+
+## Intentionally permanent loops
+
+- `main.c` is the cooperative firmware scheduler and runs for the life of the
+  device.
+- `ui/lock.c` owns the password screen until the user unlocks it; its inner
+  wait is released by the SysTick interrupt.
+- `driver/systick.c` implements requested microsecond delays while verifying
+  that the counter advances.
+- `app/uart_protocol.c` drains a finite DMA ring-buffer snapshot.
+- `sram-overlay.c` waits forever only after requesting a CPU reset, because
+  returning to normal execution after that request is unsafe.
+
+The host suite injects stuck-register and EEPROM ACK/data failures to verify
+bounded return, diagnostic latching, safe read defaults, and status
+propagation. Physical timing and the PA-disable signal are part of the hardware
+release checklist.

--- a/driver/aes.c
+++ b/driver/aes.c
@@ -18,6 +18,7 @@
 
 #include "bsp/dp32g030/aes.h"
 #include "driver/aes.h"
+#include "driver/hardware.h"
 
 static void AES_Setup_ENC_CBC(bool IsDecrypt, const void *pKey, const void *pIv)
 {
@@ -37,7 +38,7 @@ static void AES_Setup_ENC_CBC(bool IsDecrypt, const void *pKey, const void *pIv)
 	AES_CR = (AES_CR & ~AES_CR_EN_MASK) | AES_CR_EN_BITS_ENABLE;
 }
 
-static void AES_Transform(const void *pIn, void *pOut)
+static bool AES_Transform(const void *pIn, void *pOut)
 {
 	const uint32_t *pI = (const uint32_t *)pIn;
 	uint32_t *pO = (uint32_t *)pOut;
@@ -47,7 +48,10 @@ static void AES_Transform(const void *pIn, void *pOut)
 	AES_DINR = pI[2];
 	AES_DINR = pI[3];
 
-	while ((AES_SR & AES_SR_CCF_MASK) == AES_SR_CCF_BITS_NOT_COMPLETE) {
+	if (!HARDWARE_WaitForRegister(&AES_SR, AES_SR_CCF_MASK, AES_SR_CCF_BITS_COMPLETE, 100000U)) {
+		AES_CR = (AES_CR & ~AES_CR_EN_MASK) | AES_CR_EN_BITS_DISABLE;
+		HARDWARE_ReportFault(HARDWARE_FAULT_AES);
+		return false;
 	}
 
 	pO[0] = AES_DOUTR;
@@ -56,9 +60,10 @@ static void AES_Transform(const void *pIn, void *pOut)
 	pO[3] = AES_DOUTR;
 
 	AES_CR |= AES_CR_CCFC_BITS_SET;
+	return true;
 }
 
-void AES_Encrypt(const void *pKey, const void *pIv, const void *pIn, void *pOut, uint8_t NumBlocks)
+bool AES_Encrypt(const void *pKey, const void *pIv, const void *pIn, void *pOut, uint8_t NumBlocks)
 {
 	const uint8_t *pI = (const uint8_t *)pIn;
 	uint8_t *pO = (uint8_t *)pOut;
@@ -66,7 +71,9 @@ void AES_Encrypt(const void *pKey, const void *pIv, const void *pIn, void *pOut,
 
 	AES_Setup_ENC_CBC(0, pKey, pIv);
 	for (i = 0; i < NumBlocks; i++) {
-		AES_Transform(pI + (i * 16), pO + (i * 16));
+		if (!AES_Transform(pI + (i * 16), pO + (i * 16))) {
+			return false;
+		}
 	}
+	return true;
 }
-

--- a/driver/aes.h
+++ b/driver/aes.h
@@ -17,9 +17,9 @@
 #ifndef DRIVER_AES_H
 #define DRIVER_AES_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
-void AES_Encrypt(const void *pKey, const void *pIv, const void *pIn, void *pOut, uint8_t NumBlocks);
+bool AES_Encrypt(const void *pKey, const void *pIv, const void *pIn, void *pOut, uint8_t NumBlocks);
 
 #endif
-

--- a/driver/bk4819.c
+++ b/driver/bk4819.c
@@ -18,6 +18,7 @@
 #include "bsp/dp32g030/gpio.h"
 #include "bsp/dp32g030/portcon.h"
 #include "driver/gpio.h"
+#include "driver/hardware.h"
 #include "driver/system.h"
 #include "driver/systick.h"
 
@@ -831,10 +832,11 @@ uint8_t BK4819_GetCTCType(void)
 }
 
 #if defined(ENABLE_AIRCOPY)
-void BK4819_SendFSKData(uint16_t *pData)
+bool BK4819_SendFSKData(uint16_t *pData)
 {
 	uint8_t i;
 	uint8_t Timeout;
+	bool Complete = false;
 
 	Timeout = 200;
 
@@ -854,6 +856,7 @@ void BK4819_SendFSKData(uint16_t *pData)
 
 	while (Timeout) {
 		if (BK4819_ReadRegister(BK4819_REG_0C) & 1U) {
+			Complete = true;
 			break;
 		}
 		SYSTEM_DelayMs(5);
@@ -863,6 +866,10 @@ void BK4819_SendFSKData(uint16_t *pData)
 	BK4819_WriteRegister(BK4819_REG_02, 0);
 	SYSTEM_DelayMs(20);
 	BK4819_ResetFSK();
+	if (!Complete) {
+		HARDWARE_ReportFault(HARDWARE_FAULT_BK4819);
+	}
+	return Complete;
 }
 
 void BK4819_PrepareFSKReceive(void)
@@ -964,4 +971,3 @@ void BK4819_PlayDTMFEx(bool bLocalLoopback, char Code)
 	BK4819_PlayDTMF(Code);
 	BK4819_ExitTxMute();
 }
-

--- a/driver/bk4819.h
+++ b/driver/bk4819.h
@@ -125,7 +125,7 @@ uint8_t BK4819_GetDTMF_5TONE_Code(void);
 uint8_t BK4819_GetCDCSSCodeType(void);
 uint8_t BK4819_GetCTCType(void);
 
-void BK4819_SendFSKData(uint16_t *pData);
+bool BK4819_SendFSKData(uint16_t *pData);
 void BK4819_PrepareFSKReceive(void);
 
 void BK4819_PlayRoger(void);
@@ -138,4 +138,3 @@ void BK4819_SetScrambleFrequencyControlWord(uint32_t Frequency);
 void BK4819_PlayDTMFEx(bool bLocalLoopback, char Code);
 
 #endif
-

--- a/driver/eeprom.c
+++ b/driver/eeprom.c
@@ -14,42 +14,61 @@
  *     limitations under the License.
  */
 
+#include <stdbool.h>
+#include <string.h>
+
 #include "driver/eeprom.h"
+#include "driver/hardware.h"
 #include "driver/i2c.h"
 #include "driver/system.h"
 
-void EEPROM_ReadBuffer(uint16_t Address, void *pBuffer, uint8_t Size)
+bool EEPROM_ReadBuffer(uint16_t Address, void *pBuffer, uint8_t Size)
 {
+	bool Success = false;
+
+	if (Size == 0U) {
+		return true;
+	}
+	memset(pBuffer, 0xFF, Size);
 	I2C_Start();
 
-	I2C_Write(0xA0);
-
-	I2C_Write((Address >> 8) & 0xFF);
-	I2C_Write((Address >> 0) & 0xFF);
+	if (I2C_Write(0xA0) < 0 || I2C_Write((Address >> 8) & 0xFF) < 0 || I2C_Write((Address >> 0) & 0xFF) < 0) {
+		goto cleanup;
+	}
 
 	I2C_Start();
 
-	I2C_Write(0xA1);
+	if (I2C_Write(0xA1) < 0 || I2C_ReadBuffer(pBuffer, Size) != Size) {
+		goto cleanup;
+	}
+	Success = true;
 
-	I2C_ReadBuffer(pBuffer, Size);
-
+cleanup:
 	I2C_Stop();
+	if (!Success) {
+		memset(pBuffer, 0xFF, Size);
+		HARDWARE_ReportFault(HARDWARE_FAULT_EEPROM);
+	}
+	return Success;
 }
 
-void EEPROM_WriteBuffer(uint16_t Address, const void *pBuffer)
-
+bool EEPROM_WriteBuffer(uint16_t Address, const void *pBuffer)
 {
+	bool Success = false;
+
 	I2C_Start();
 
-	I2C_Write(0xA0);
+	if (I2C_Write(0xA0) < 0 || I2C_Write((Address >> 8) & 0xFF) < 0 || I2C_Write((Address >> 0) & 0xFF) < 0 || I2C_WriteBuffer(pBuffer, 8) < 0) {
+		goto cleanup;
+	}
+	Success = true;
 
-	I2C_Write((Address >> 8) & 0xFF);
-	I2C_Write((Address >> 0) & 0xFF);
-
-	I2C_WriteBuffer(pBuffer, 8);
-
+cleanup:
 	I2C_Stop();
-
-	SYSTEM_DelayMs(10);
+	if (Success) {
+		SYSTEM_DelayMs(10);
+	} else {
+		HARDWARE_ReportFault(HARDWARE_FAULT_EEPROM);
+	}
+	return Success;
 }
-

--- a/driver/eeprom.h
+++ b/driver/eeprom.h
@@ -17,10 +17,10 @@
 #ifndef DRIVER_EEPROM_H
 #define DRIVER_EEPROM_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
-void EEPROM_ReadBuffer(uint16_t Address, void *pBuffer, uint8_t Size);
-void EEPROM_WriteBuffer(uint16_t Address, const void *pBuffer);
+bool EEPROM_ReadBuffer(uint16_t Address, void *pBuffer, uint8_t Size);
+bool EEPROM_WriteBuffer(uint16_t Address, const void *pBuffer);
 
 #endif
-

--- a/driver/flash.c
+++ b/driver/flash.c
@@ -17,18 +17,17 @@
 #include "driver/flash.h"
 #include "sram-overlay.h"
 
-void FLASH_Init(FLASH_READ_MODE ReadMode)
+bool FLASH_Init(FLASH_READ_MODE ReadMode)
 {
-	overlay_FLASH_Init(ReadMode);
+	return overlay_FLASH_Init(ReadMode);
 }
 
-void FLASH_ConfigureTrimValues(void)
+bool FLASH_ConfigureTrimValues(void)
 {
-	overlay_FLASH_ConfigureTrimValues();
+	return overlay_FLASH_ConfigureTrimValues();
 }
 
 uint32_t FLASH_ReadNvrWord(uint32_t Address)
 {
 	return overlay_FLASH_ReadNvrWord(Address);
 }
-

--- a/driver/flash.h
+++ b/driver/flash.h
@@ -17,6 +17,8 @@
 #ifndef DRIVER_FLASH_H
 #define DRIVER_FLASH_H
 
+#include <stdbool.h>
+
 #include "bsp/dp32g030/flash.h"
 
 enum FLASH_READ_MODE {
@@ -51,9 +53,8 @@ enum FLASH_AREA {
 
 typedef enum FLASH_AREA FLASH_AREA;
 
-void FLASH_Init(FLASH_READ_MODE ReadMode);
-void FLASH_ConfigureTrimValues(void);
+bool FLASH_Init(FLASH_READ_MODE ReadMode);
+bool FLASH_ConfigureTrimValues(void);
 uint32_t FLASH_ReadNvrWord(uint32_t Address);
 
 #endif
-

--- a/driver/hardware.c
+++ b/driver/hardware.c
@@ -1,0 +1,49 @@
+/* Copyright 2026 Open Edition contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#include "driver/hardware.h"
+
+static volatile HARDWARE_Fault_t gLastHardwareFault;
+static volatile bool gHardwareFaultPending;
+
+bool HARDWARE_WaitForRegister(const volatile uint32_t *pRegister, uint32_t Mask, uint32_t Expected, uint32_t PollLimit)
+{
+	while (PollLimit != 0U) {
+		PollLimit--;
+		if ((*pRegister & Mask) == Expected) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void HARDWARE_ReportFault(HARDWARE_Fault_t Fault)
+{
+	if (Fault != HARDWARE_FAULT_NONE) {
+		gLastHardwareFault    = Fault;
+		gHardwareFaultPending = true;
+	}
+}
+
+HARDWARE_Fault_t HARDWARE_GetLastFault(void)
+{
+	return gLastHardwareFault;
+}
+
+HARDWARE_Fault_t HARDWARE_TakePendingFault(void)
+{
+	const HARDWARE_Fault_t Fault = gHardwareFaultPending ? gLastHardwareFault : HARDWARE_FAULT_NONE;
+
+	gHardwareFaultPending = false;
+	return Fault;
+}
+
+void HARDWARE_ClearFault(void)
+{
+	gLastHardwareFault    = HARDWARE_FAULT_NONE;
+	gHardwareFaultPending = false;
+}

--- a/driver/hardware.h
+++ b/driver/hardware.h
@@ -1,0 +1,32 @@
+/* Copyright 2026 Open Edition contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#ifndef DRIVER_HARDWARE_H
+#define DRIVER_HARDWARE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+enum HARDWARE_Fault_t {
+	HARDWARE_FAULT_NONE = 0U,
+	HARDWARE_FAULT_ADC,
+	HARDWARE_FAULT_AES,
+	HARDWARE_FAULT_UART,
+	HARDWARE_FAULT_SPI,
+	HARDWARE_FAULT_EEPROM,
+	HARDWARE_FAULT_BK4819,
+	HARDWARE_FAULT_FLASH,
+};
+
+typedef enum HARDWARE_Fault_t HARDWARE_Fault_t;
+
+bool HARDWARE_WaitForRegister(const volatile uint32_t *pRegister, uint32_t Mask, uint32_t Expected, uint32_t PollLimit);
+void HARDWARE_ReportFault(HARDWARE_Fault_t Fault);
+HARDWARE_Fault_t HARDWARE_GetLastFault(void);
+HARDWARE_Fault_t HARDWARE_TakePendingFault(void);
+void HARDWARE_ClearFault(void);
+
+#endif

--- a/driver/i2c.c
+++ b/driver/i2c.c
@@ -137,6 +137,9 @@ int I2C_ReadBuffer(void *pBuffer, uint8_t Size)
 	uint8_t *pData = (uint8_t *)pBuffer;
 	uint8_t i;
 
+	if (Size == 0U) {
+		return 0;
+	}
 	if (Size == 1) {
 		*pData = I2C_Read(true);
 		return 1;
@@ -166,4 +169,3 @@ int I2C_WriteBuffer(const void *pBuffer, uint8_t Size)
 
 	return 0;
 }
-

--- a/driver/spi.c
+++ b/driver/spi.c
@@ -18,6 +18,7 @@
 #include "bsp/dp32g030/spi.h"
 #include "bsp/dp32g030/syscon.h"
 #include "bsp/dp32g030/irq.h"
+#include "driver/hardware.h"
 #include "driver/spi.h"
 
 void SPI0_Init(void)
@@ -43,18 +44,25 @@ void SPI0_Init(void)
 	SPI_Enable(&SPI0->CR);
 }
 
-void SPI_WaitForUndocumentedTxFifoStatusBit(void)
+bool SPI_WaitForTxFifoSpace(void)
 {
-	uint32_t Timeout;
+	if (HARDWARE_WaitForRegister(&SPI0->FIFOST, SPI_FIFOST_TFF_MASK, SPI_FIFOST_TFF_BITS_NOT_FULL, 100000U)) {
+		return true;
+	}
 
-	Timeout = 0;
-	do {
-		// Undocumented bit!
-		if ((SPI0->IF & 0x20) == 0) {
-			break;
-		}
-		Timeout++;
-	} while (Timeout <= 100000);
+	HARDWARE_ReportFault(HARDWARE_FAULT_SPI);
+	return false;
+}
+
+bool SPI_WaitForUndocumentedTxFifoStatusBit(void)
+{
+	// Undocumented bit: set while the transmit path is still active.
+	if (HARDWARE_WaitForRegister(&SPI0->IF, 0x20U, 0U, 100000U)) {
+		return true;
+	}
+
+	HARDWARE_ReportFault(HARDWARE_FAULT_SPI);
+	return false;
 }
 
 void SPI_Disable(volatile uint32_t *pCR)
@@ -113,4 +121,3 @@ void SPI_Enable(volatile uint32_t *pCR)
 {
 	*pCR = (*pCR & ~SPI_CR_SPE_MASK) | SPI_CR_SPE_BITS_ENABLE;
 }
-

--- a/driver/spi.h
+++ b/driver/spi.h
@@ -36,7 +36,8 @@ typedef struct {
 } SPI_Config_t;
 
 void SPI0_Init(void);
-void SPI_WaitForUndocumentedTxFifoStatusBit(void);
+bool SPI_WaitForTxFifoSpace(void);
+bool SPI_WaitForUndocumentedTxFifoStatusBit(void);
 
 void SPI_Disable(volatile uint32_t *pCR);
 void SPI_Configure(volatile SPI_Port_t *pPort, SPI_Config_t *pConfig);
@@ -44,4 +45,3 @@ void SPI_ToggleMasterMode(volatile uint32_t *pCr, bool bIsMaster);
 void SPI_Enable(volatile uint32_t *pCR);
 
 #endif
-

--- a/driver/st7565.c
+++ b/driver/st7565.c
@@ -26,120 +26,157 @@
 uint8_t gStatusLine[128];
 uint8_t gFrameBuffer[7][128];
 
-void ST7565_DrawLine(uint8_t Column, uint8_t Line, uint16_t Size, const uint8_t *pBitmap, bool bIsClearMode)
+static bool ST7565_WriteData(uint8_t Value)
+{
+	if (!SPI_WaitForTxFifoSpace()) {
+		return false;
+	}
+	SPI0->WDR = Value;
+	return true;
+}
+
+bool ST7565_DrawLine(uint8_t Column, uint8_t Line, uint16_t Size, const uint8_t *pBitmap, bool bIsClearMode)
 {
 	uint16_t i;
+	bool Success = false;
 
 	SPI_ToggleMasterMode(&SPI0->CR, false);
-	ST7565_SelectColumnAndLine(Column + 4U, Line);
+	if (!ST7565_SelectColumnAndLine(Column + 4U, Line)) {
+		goto cleanup;
+	}
 	GPIO_SetBit(&GPIOB->DATA, GPIOB_PIN_ST7565_A0);
 
 	if (!bIsClearMode) {
 		for (i = 0; i < Size; i++) {
-			while ((SPI0->FIFOST & SPI_FIFOST_TFF_MASK) != SPI_FIFOST_TFF_BITS_NOT_FULL) {
+			if (!ST7565_WriteData(pBitmap[i])) {
+				goto cleanup;
 			}
-			SPI0->WDR = pBitmap[i];
 		}
 	} else {
 		for (i = 0; i < Size; i++) {
-			while ((SPI0->FIFOST & SPI_FIFOST_TFF_MASK) != SPI_FIFOST_TFF_BITS_NOT_FULL) {
+			if (!ST7565_WriteData(0)) {
+				goto cleanup;
 			}
-			SPI0->WDR = 0;
 		}
 	}
 
-	SPI_WaitForUndocumentedTxFifoStatusBit();
+	Success = SPI_WaitForUndocumentedTxFifoStatusBit();
+cleanup:
 	SPI_ToggleMasterMode(&SPI0->CR, true);
+	return Success;
 }
 
-void ST7565_BlitFullScreen(void)
+bool ST7565_BlitFullScreen(void)
 {
 	uint8_t Line;
 	uint8_t Column;
+	bool Success = false;
 
 	SPI_ToggleMasterMode(&SPI0->CR, false);
-	ST7565_WriteByte(0x40);
+	if (!ST7565_WriteByte(0x40)) {
+		goto cleanup;
+	}
 
 	for (Line = 0; Line < ARRAY_SIZE(gFrameBuffer); Line++) {
-		ST7565_SelectColumnAndLine(4U, Line + 1U);
+		if (!ST7565_SelectColumnAndLine(4U, Line + 1U)) {
+			goto cleanup;
+		}
 		GPIO_SetBit(&GPIOB->DATA, GPIOB_PIN_ST7565_A0);
 		for (Column = 0; Column < ARRAY_SIZE(gFrameBuffer[0]); Column++) {
-			while ((SPI0->FIFOST & SPI_FIFOST_TFF_MASK) != SPI_FIFOST_TFF_BITS_NOT_FULL) {
+			if (!ST7565_WriteData(gFrameBuffer[Line][Column])) {
+				goto cleanup;
 			}
-			SPI0->WDR = gFrameBuffer[Line][Column];
 		}
-		SPI_WaitForUndocumentedTxFifoStatusBit();
+		if (!SPI_WaitForUndocumentedTxFifoStatusBit()) {
+			goto cleanup;
+		}
 	}
 
 	SYSTEM_DelayMs(20);
+	Success = true;
+cleanup:
 	SPI_ToggleMasterMode(&SPI0->CR, true);
+	return Success;
 }
 
-void ST7565_BlitStatusLine(void)
+bool ST7565_BlitStatusLine(void)
 {
 	uint8_t i;
+	bool Success = false;
 
 	SPI_ToggleMasterMode(&SPI0->CR, false);
-	ST7565_WriteByte(0x40);
-	ST7565_SelectColumnAndLine(4, 0);
+	if (!ST7565_WriteByte(0x40) || !ST7565_SelectColumnAndLine(4, 0)) {
+		goto cleanup;
+	}
 	GPIO_SetBit(&GPIOB->DATA, GPIOB_PIN_ST7565_A0);
 
 	for (i = 0; i < ARRAY_SIZE(gStatusLine); i++) {
-		while ((SPI0->FIFOST & SPI_FIFOST_TFF_MASK) != SPI_FIFOST_TFF_BITS_NOT_FULL) {
+		if (!ST7565_WriteData(gStatusLine[i])) {
+			goto cleanup;
 		}
-		SPI0->WDR = gStatusLine[i];
 	}
-	SPI_WaitForUndocumentedTxFifoStatusBit();
+	Success = SPI_WaitForUndocumentedTxFifoStatusBit();
+cleanup:
 	SPI_ToggleMasterMode(&SPI0->CR, true);
+	return Success;
 }
 
-void ST7565_FillScreen(uint8_t Value)
+bool ST7565_FillScreen(uint8_t Value)
 {
 	uint8_t i, j;
+	bool Success = false;
 
 	SPI_ToggleMasterMode(&SPI0->CR, false);
 	for (i = 0; i < 8; i++) {
-		ST7565_SelectColumnAndLine(0, i);
+		if (!ST7565_SelectColumnAndLine(0, i)) {
+			goto cleanup;
+		}
 		GPIO_SetBit(&GPIOB->DATA, GPIOB_PIN_ST7565_A0);
 		for (j = 0; j < 132; j++) {
-			while ((SPI0->FIFOST & SPI_FIFOST_TFF_MASK) != SPI_FIFOST_TFF_BITS_NOT_FULL) {
+			if (!ST7565_WriteData(Value)) {
+				goto cleanup;
 			}
-			SPI0->WDR = Value;
 		}
-		SPI_WaitForUndocumentedTxFifoStatusBit();
+		if (!SPI_WaitForUndocumentedTxFifoStatusBit()) {
+			goto cleanup;
+		}
 	}
+	Success = true;
+cleanup:
 	SPI_ToggleMasterMode(&SPI0->CR, true);
+	return Success;
 }
 
-void ST7565_Init(void)
+bool ST7565_Init(void)
 {
+	bool Success = false;
+
 	SPI0_Init();
 	ST7565_HardwareReset();
 	SPI_ToggleMasterMode(&SPI0->CR, false);
-	ST7565_WriteByte(0xE2);
+	if (!ST7565_WriteByte(0xE2)) {
+		goto cleanup;
+	}
 	SYSTEM_DelayMs(0x78);
-	ST7565_WriteByte(0xA2);
-	ST7565_WriteByte(0xC0);
-	ST7565_WriteByte(0xA1);
-	ST7565_WriteByte(0xA6);
-	ST7565_WriteByte(0xA4);
-	ST7565_WriteByte(0x24);
-	ST7565_WriteByte(0x81);
-	ST7565_WriteByte(0x1F);
-	ST7565_WriteByte(0x2B);
+	if (!ST7565_WriteByte(0xA2) || !ST7565_WriteByte(0xC0) || !ST7565_WriteByte(0xA1) || !ST7565_WriteByte(0xA6) || !ST7565_WriteByte(0xA4) || !ST7565_WriteByte(0x24) || !ST7565_WriteByte(0x81) || !ST7565_WriteByte(0x1F) || !ST7565_WriteByte(0x2B)) {
+		goto cleanup;
+	}
 	SYSTEM_DelayMs(1);
-	ST7565_WriteByte(0x2E);
+	if (!ST7565_WriteByte(0x2E)) {
+		goto cleanup;
+	}
 	SYSTEM_DelayMs(1);
-	ST7565_WriteByte(0x2F);
-	ST7565_WriteByte(0x2F);
-	ST7565_WriteByte(0x2F);
-	ST7565_WriteByte(0x2F);
+	if (!ST7565_WriteByte(0x2F) || !ST7565_WriteByte(0x2F) || !ST7565_WriteByte(0x2F) || !ST7565_WriteByte(0x2F)) {
+		goto cleanup;
+	}
 	SYSTEM_DelayMs(0x28);
-	ST7565_WriteByte(0x40);
-	ST7565_WriteByte(0xAF);
-	SPI_WaitForUndocumentedTxFifoStatusBit();
+	if (!ST7565_WriteByte(0x40) || !ST7565_WriteByte(0xAF) || !SPI_WaitForUndocumentedTxFifoStatusBit()) {
+		goto cleanup;
+	}
+	Success = true;
+cleanup:
 	SPI_ToggleMasterMode(&SPI0->CR, true);
-	ST7565_FillScreen(0x00);
+	return Success && ST7565_FillScreen(0x00);
 }
 
 void ST7565_HardwareReset(void)
@@ -152,26 +189,23 @@ void ST7565_HardwareReset(void)
 	SYSTEM_DelayMs(120);
 }
 
-void ST7565_SelectColumnAndLine(uint8_t Column, uint8_t Line)
+bool ST7565_SelectColumnAndLine(uint8_t Column, uint8_t Line)
 {
 	GPIO_ClearBit(&GPIOB->DATA, GPIOB_PIN_ST7565_A0);
-	while ((SPI0->FIFOST & SPI_FIFOST_TFF_MASK) != SPI_FIFOST_TFF_BITS_NOT_FULL) {
+	if (!ST7565_WriteData(Line + 0xB0)) {
+		return false;
 	}
-	SPI0->WDR = Line + 0xB0;
-	while ((SPI0->FIFOST & SPI_FIFOST_TFF_MASK) != SPI_FIFOST_TFF_BITS_NOT_FULL) {
+	if (!ST7565_WriteData(((Column >> 4) & 0x0F) | 0x10)) {
+		return false;
 	}
-	SPI0->WDR = ((Column >> 4) & 0x0F) | 0x10;
-	while ((SPI0->FIFOST & SPI_FIFOST_TFF_MASK) != SPI_FIFOST_TFF_BITS_NOT_FULL) {
+	if (!ST7565_WriteData(((Column >> 0) & 0x0F))) {
+		return false;
 	}
-	SPI0->WDR = ((Column >> 0) & 0x0F);
-	SPI_WaitForUndocumentedTxFifoStatusBit();
+	return SPI_WaitForUndocumentedTxFifoStatusBit();
 }
 
-void ST7565_WriteByte(uint8_t Value)
+bool ST7565_WriteByte(uint8_t Value)
 {
 	GPIO_ClearBit(&GPIOB->DATA, GPIOB_PIN_ST7565_A0);
-	while ((SPI0->FIFOST & SPI_FIFOST_TFF_MASK) != SPI_FIFOST_TFF_BITS_NOT_FULL) {
-	}
-	SPI0->WDR = Value;
+	return ST7565_WriteData(Value);
 }
-

--- a/driver/st7565.h
+++ b/driver/st7565.h
@@ -23,14 +23,13 @@
 extern uint8_t gStatusLine[128];
 extern uint8_t gFrameBuffer[7][128];
 
-void ST7565_DrawLine(uint8_t Column, uint8_t Line, uint16_t Size, const uint8_t *pBitmap, bool bIsClearMode);
-void ST7565_BlitFullScreen(void);
-void ST7565_BlitStatusLine(void);
-void ST7565_FillScreen(uint8_t Value);
-void ST7565_Init(void);
+bool ST7565_DrawLine(uint8_t Column, uint8_t Line, uint16_t Size, const uint8_t *pBitmap, bool bIsClearMode);
+bool ST7565_BlitFullScreen(void);
+bool ST7565_BlitStatusLine(void);
+bool ST7565_FillScreen(uint8_t Value);
+bool ST7565_Init(void);
 void ST7565_HardwareReset(void);
-void ST7565_SelectColumnAndLine(uint8_t Column, uint8_t Line);
-void ST7565_WriteByte(uint8_t Value);
+bool ST7565_SelectColumnAndLine(uint8_t Column, uint8_t Line);
+bool ST7565_WriteByte(uint8_t Value);
 
 #endif
-

--- a/driver/uart.c
+++ b/driver/uart.c
@@ -18,6 +18,7 @@
 #include "bsp/dp32g030/dma.h"
 #include "bsp/dp32g030/syscon.h"
 #include "bsp/dp32g030/uart.h"
+#include "driver/hardware.h"
 #include "driver/uart.h"
 
 static bool UART_IsLogEnabled;
@@ -84,22 +85,26 @@ void UART_Init(void)
 	UART1->CTRL |= UART_CTRL_UARTEN_BITS_ENABLE;
 }
 
-void UART_Send(const void *pBuffer, uint32_t Size)
+bool UART_Send(const void *pBuffer, uint32_t Size)
 {
 	const uint8_t *pData = (const uint8_t *)pBuffer;
 	uint32_t i;
 
 	for (i = 0; i < Size; i++) {
 		UART1->TDR = pData[i];
-		while ((UART1->IF & UART_IF_TXFIFO_FULL_MASK) != UART_IF_TXFIFO_FULL_BITS_NOT_SET) {
+		if (!HARDWARE_WaitForRegister(&UART1->IF, UART_IF_TXFIFO_FULL_MASK, UART_IF_TXFIFO_FULL_BITS_NOT_SET, 100000U)) {
+			UART1->FIFO |= UART_FIFO_TF_CLR_BITS_ENABLE;
+			HARDWARE_ReportFault(HARDWARE_FAULT_UART);
+			return false;
 		}
 	}
+	return true;
 }
 
-void UART_LogSend(const void *pBuffer, uint32_t Size)
+bool UART_LogSend(const void *pBuffer, uint32_t Size)
 {
 	if (UART_IsLogEnabled) {
-		UART_Send(pBuffer, Size);
+		return UART_Send(pBuffer, Size);
 	}
+	return true;
 }
-

--- a/driver/uart.h
+++ b/driver/uart.h
@@ -18,13 +18,13 @@
 #ifndef DRIVER_UART_H
 #define DRIVER_UART_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 extern uint8_t UART_DMA_Buffer[256];
 
 void UART_Init(void);
-void UART_Send(const void *pBuffer, uint32_t Size);
-void UART_LogSend(const void *pBuffer, uint32_t Size);
+bool UART_Send(const void *pBuffer, uint32_t Size);
+bool UART_LogSend(const void *pBuffer, uint32_t Size);
 
 #endif
-

--- a/radio.c
+++ b/radio.c
@@ -25,6 +25,7 @@
 #include "driver/bk4819.h"
 #include "driver/eeprom.h"
 #include "driver/gpio.h"
+#include "driver/hardware.h"
 #include "driver/system.h"
 #include "eeprom_validation.h"
 #include "frequencies.h"
@@ -478,12 +479,13 @@ void RADIO_SelectVfos(void)
 	RADIO_SelectCurrentVfo();
 }
 
-void RADIO_SetupRegisters(bool bSwitchToFunction0)
+bool RADIO_SetupRegisters(bool bSwitchToFunction0)
 {
 	BK4819_FilterBandwidth_t Bandwidth;
 	uint16_t Status;
 	uint16_t InterruptMask;
 	uint32_t Frequency;
+	uint8_t PollLimit = 100U;
 
 	GPIO_ClearBit(&GPIOC->DATA, GPIOC_PIN_AUDIO_PATH);
 	gEnableSpeaker = false;
@@ -500,13 +502,18 @@ void RADIO_SetupRegisters(bool bSwitchToFunction0)
 	BK4819_SetupPowerAmplifier(0, 0);
 	BK4819_ToggleGpioOut(BK4819_GPIO1_PIN29_PA_ENABLE, false);
 
-	while (1) {
+	do {
 		Status = BK4819_ReadRegister(BK4819_REG_0C);
 		if ((Status & 1U) == 0) { // INTERRUPT REQUEST
 			break;
 		}
 		BK4819_WriteRegister(BK4819_REG_02, 0);
 		SYSTEM_DelayMs(1);
+	} while (PollLimit-- != 0U);
+	if ((Status & 1U) != 0) {
+		HARDWARE_ReportFault(HARDWARE_FAULT_BK4819);
+		RADIO_ForceSafeState();
+		return false;
 	}
 	BK4819_WriteRegister(BK4819_REG_3F, 0);
 	BK4819_WriteRegister(BK4819_REG_7D, gEeprom.MIC_SENSITIVITY_TUNING | 0xE940);
@@ -619,6 +626,7 @@ void RADIO_SetupRegisters(bool bSwitchToFunction0)
 	if (bSwitchToFunction0) {
 		FUNCTION_Select(FUNCTION_FOREGROUND);
 	}
+	return true;
 }
 
 #if defined(ENABLE_NOAA)
@@ -731,8 +739,29 @@ void RADIO_SetVfoState(VfoState_t State)
 	gUpdateDisplay = true;
 }
 
+void RADIO_ForceSafeState(void)
+{
+	GPIO_ClearBit(&GPIOC->DATA, GPIOC_PIN_AUDIO_PATH);
+	gEnableSpeaker = false;
+	BK4819_WriteRegister(BK4819_REG_30, 0);
+	BK4819_SetupPowerAmplifier(0, 0);
+	BK4819_ToggleGpioOut(BK4819_GPIO1_PIN29_PA_ENABLE, false);
+	BK4819_ToggleGpioOut(BK4819_GPIO5_PIN1_RED, false);
+	gPttIsPressed	     = false;
+	gFlagPrepareTX	     = false;
+	gFlagEndTransmission = false;
+	gTxTimerCountdown    = 0;
+	FUNCTION_Select(FUNCTION_FOREGROUND);
+	RADIO_SetVfoState(VFO_STATE_TX_DISABLE);
+}
+
 void RADIO_PrepareTX(void)
 {
+	if (HARDWARE_GetLastFault() != HARDWARE_FAULT_NONE) {
+		RADIO_ForceSafeState();
+		return;
+	}
+
 	if (gEeprom.DUAL_WATCH != DUAL_WATCH_OFF) {
 		gDualWatchCountdown = 360;
 		gScheduleDualWatch = false;

--- a/radio.h
+++ b/radio.h
@@ -128,15 +128,15 @@ void RADIO_ConfigureChannel(uint8_t RadioNum, uint32_t Arg);
 void RADIO_ConfigureSquelchAndOutputPower(VFO_Info_t *pInfo);
 void RADIO_ApplyOffset(VFO_Info_t *pInfo);
 void RADIO_SelectVfos(void);
-void RADIO_SetupRegisters(bool bSwitchToFunction0);
+bool RADIO_SetupRegisters(bool bSwitchToFunction0);
 void RADIO_ConfigureNOAA(void);
 void RADIO_SetTxParameters(void);
 
 void RADIO_SetVfoState(VfoState_t State);
+void RADIO_ForceSafeState(void);
 void RADIO_PrepareTX(void);
 void RADIO_EnableCxCSS(void);
 void RADIO_PrepareCssTX(void);
 void RADIO_SendEndOfTransmission(void);
 
 #endif
-

--- a/sram-overlay.c
+++ b/sram-overlay.c
@@ -20,6 +20,8 @@
 #include "bsp/dp32g030/syscon.h"
 #include "sram-overlay.h"
 
+#define FLASH_POLL_LIMIT 1000000U
+
 static volatile uint32_t *pFlash = 0;
 uint32_t overlay_FLASH_MainClock;
 uint32_t overlay_FLASH_ClockMultiplier;
@@ -49,14 +51,17 @@ void overlay_FLASH_Start(void)
 	FLASH_START |= FLASH_START_START_BITS_START;
 }
 
-void overlay_FLASH_Init(FLASH_READ_MODE ReadMode)
+bool overlay_FLASH_Init(FLASH_READ_MODE ReadMode)
 {
-	overlay_FLASH_WakeFromDeepSleep();
+	if (!overlay_FLASH_WakeFromDeepSleep()) {
+		return false;
+	}
 	overlay_FLASH_SetMode(FLASH_MODE_READ_AHB);
 	overlay_FLASH_SetReadMode(ReadMode);
 	overlay_FLASH_SetEraseTime();
 	overlay_FLASH_SetProgramTime();
 	overlay_FLASH_Lock();
+	return true;
 }
 
 void overlay_FLASH_MaskLock(void)
@@ -90,11 +95,14 @@ uint32_t overlay_FLASH_ReadByAHB(uint32_t Offset)
 	return pFlash[(Offset & ~3U) / 4];
 }
 
-uint32_t overlay_FLASH_ReadByAPB(uint32_t Offset)
+bool overlay_FLASH_ReadByAPB(uint32_t Offset, uint32_t *pData)
 {
-	uint32_t Data;
+	uint32_t Timeout = FLASH_POLL_LIMIT;
 
 	while (overlay_FLASH_IsBusy()) {
+		if (Timeout-- == 0U) {
+			return false;
+		}
 	}
 
 	overlay_FLASH_SetMode(FLASH_MODE_READ_APB);
@@ -102,15 +110,21 @@ uint32_t overlay_FLASH_ReadByAPB(uint32_t Offset)
 
 	overlay_FLASH_Start();
 
+	Timeout = FLASH_POLL_LIMIT;
 	while (overlay_FLASH_IsBusy()) {
+		if (Timeout-- == 0U) {
+			overlay_FLASH_SetMode(FLASH_MODE_READ_AHB);
+			overlay_FLASH_Lock();
+			return false;
+		}
 	}
 
-	Data = FLASH_RDATA;
+	*pData = FLASH_RDATA;
 
 	overlay_FLASH_SetMode(FLASH_MODE_READ_AHB);
 	overlay_FLASH_Lock();
 
-	return Data;
+	return true;
 }
 
 void overlay_FLASH_SetArea(FLASH_AREA Area)
@@ -132,11 +146,17 @@ void overlay_FLASH_SetEraseTime(void)
 	FLASH_ERASETIME = ((overlay_FLASH_ClockMultiplier & 0xFFFFU) * 0x1A00000U) + (overlay_FLASH_ClockMultiplier * 3600U);
 }
 
-void overlay_FLASH_WakeFromDeepSleep(void)
+bool overlay_FLASH_WakeFromDeepSleep(void)
 {
+	uint32_t Timeout = FLASH_POLL_LIMIT;
+
 	FLASH_CFG = (FLASH_CFG & ~FLASH_CFG_DEEP_PD_MASK) | FLASH_CFG_DEEP_PD_BITS_NORMAL;
 	while (!overlay_FLASH_IsInitComplete()) {
+		if (Timeout-- == 0U) {
+			return false;
+		}
 	}
+	return true;
 }
 
 void overlay_FLASH_SetMode(FLASH_MODE Mode)
@@ -178,16 +198,32 @@ uint32_t overlay_FLASH_ReadNvrWord(uint32_t Offset)
 	return Data;
 }
 
-void overlay_FLASH_ConfigureTrimValues(void)
+bool overlay_FLASH_ConfigureTrimValues(void)
 {
 	uint32_t Data;
 
 	overlay_FLASH_SetArea(FLASH_AREA_NVR);
 
-	SYSCON_CHIP_ID0 = overlay_FLASH_ReadByAPB(0xF018);
-	SYSCON_CHIP_ID1 = overlay_FLASH_ReadByAPB(0xF01C);
-	SYSCON_CHIP_ID2 = overlay_FLASH_ReadByAPB(0xF020);
-	SYSCON_CHIP_ID3 = overlay_FLASH_ReadByAPB(0xF024);
+	if (!overlay_FLASH_ReadByAPB(0xF018, &Data)) {
+		overlay_FLASH_SetArea(FLASH_AREA_MAIN);
+		return false;
+	}
+	SYSCON_CHIP_ID0 = Data;
+	if (!overlay_FLASH_ReadByAPB(0xF01C, &Data)) {
+		overlay_FLASH_SetArea(FLASH_AREA_MAIN);
+		return false;
+	}
+	SYSCON_CHIP_ID1 = Data;
+	if (!overlay_FLASH_ReadByAPB(0xF020, &Data)) {
+		overlay_FLASH_SetArea(FLASH_AREA_MAIN);
+		return false;
+	}
+	SYSCON_CHIP_ID2 = Data;
+	if (!overlay_FLASH_ReadByAPB(0xF024, &Data)) {
+		overlay_FLASH_SetArea(FLASH_AREA_MAIN);
+		return false;
+	}
+	SYSCON_CHIP_ID3 = Data;
 
 	SYSCON_RC_FREQ_DELTA = overlay_FLASH_ReadByAHB(0x07C8);
 	SYSCON_VREF_VOLT_DELTA = overlay_FLASH_ReadByAHB(0x07C4);
@@ -206,5 +242,5 @@ void overlay_FLASH_ConfigureTrimValues(void)
 	SARADC_CALIB_OFFSET = ((Data & 0xFFFF) << SARADC_CALIB_OFFSET_OFFSET_SHIFT) & SARADC_CALIB_OFFSET_OFFSET_MASK;
 	SARADC_CALIB_KD = (((Data >> 16) & 0xFFFF) << SARADC_CALIB_KD_KD_SHIFT) & SARADC_CALIB_KD_KD_MASK;
 	overlay_FLASH_SetArea(FLASH_AREA_MAIN);
+	return true;
 }
-

--- a/sram-overlay.h
+++ b/sram-overlay.h
@@ -29,23 +29,22 @@ void overlay_FLASH_RebootToBootloader(void) __attribute__((noreturn)) __attribut
 bool overlay_FLASH_IsBusy(void) __attribute__((section(".sramtext")));
 bool overlay_FLASH_IsInitComplete(void) __attribute__((section(".sramtext")));
 void overlay_FLASH_Start(void) __attribute__((section(".sramtext")));
-void overlay_FLASH_Init(FLASH_READ_MODE ReadMode) __attribute__((section(".sramtext")));
+bool overlay_FLASH_Init(FLASH_READ_MODE ReadMode) __attribute__((section(".sramtext")));
 void overlay_FLASH_MaskLock(void) __attribute__((section(".sramtext")));
 void overlay_FLASH_SetMaskSel(FLASH_MASK_SELECTION Mask) __attribute__((section(".sramtext")));
 void overlay_FLASH_MaskUnlock(void) __attribute__((section(".sramtext")));
 void overlay_FLASH_Lock(void) __attribute__((section(".sramtext")));
 void overlay_FLASH_Unlock(void) __attribute__((section(".sramtext")));
 uint32_t overlay_FLASH_ReadByAHB(uint32_t Offset) __attribute__((section(".sramtext")));
-uint32_t overlay_FLASH_ReadByAPB(uint32_t Offset) __attribute__((section(".sramtext")));
+bool overlay_FLASH_ReadByAPB(uint32_t Offset, uint32_t *pData) __attribute__((section(".sramtext")));
 void overlay_FLASH_SetArea(FLASH_AREA Area) __attribute__((section(".sramtext")));
 void overlay_FLASH_SetReadMode(FLASH_READ_MODE Mode) __attribute__((section(".sramtext")));
 void overlay_FLASH_SetEraseTime(void) __attribute__((section(".sramtext")));
-void overlay_FLASH_WakeFromDeepSleep(void) __attribute__((section(".sramtext")));
+bool overlay_FLASH_WakeFromDeepSleep(void) __attribute__((section(".sramtext")));
 void overlay_FLASH_SetMode(FLASH_MODE Mode) __attribute__((section(".sramtext")));
 void overlay_FLASH_SetProgramTime(void) __attribute__((section(".sramtext")));
 void overlay_SystemReset(void) __attribute__((noreturn)) __attribute__((section(".sramtext")));
 uint32_t overlay_FLASH_ReadNvrWord(uint32_t Offset) __attribute__((section(".sramtext")));
-void overlay_FLASH_ConfigureTrimValues(void) __attribute__((section(".sramtext")));
+bool overlay_FLASH_ConfigureTrimValues(void) __attribute__((section(".sramtext")));
 
 #endif
-

--- a/tests/host/eeprom_driver_harness.c
+++ b/tests/host/eeprom_driver_harness.c
@@ -1,0 +1,46 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "driver/eeprom.h"
+
+static bool gFailAddressWrite;
+static bool gFailDataWrite;
+
+void HOST_EepromDriver_Reset(bool FailAddressWrite, bool FailDataWrite)
+{
+	gFailAddressWrite = FailAddressWrite;
+	gFailDataWrite	  = FailDataWrite;
+}
+
+void I2C_Start(void)
+{
+}
+
+void I2C_Stop(void)
+{
+}
+
+int I2C_Write(uint8_t Data)
+{
+	(void)Data;
+	return gFailAddressWrite ? -1 : 0;
+}
+
+int I2C_ReadBuffer(void *pBuffer, uint8_t Size)
+{
+	memset(pBuffer, 0x5A, Size);
+	return Size;
+}
+
+int I2C_WriteBuffer(const void *pBuffer, uint8_t Size)
+{
+	(void)pBuffer;
+	(void)Size;
+	return gFailDataWrite ? -1 : 0;
+}
+
+void SYSTEM_DelayMs(uint32_t Delay)
+{
+	(void)Delay;
+}

--- a/tests/test_eeprom_driver_faults.py
+++ b/tests/test_eeprom_driver_faults.py
@@ -1,0 +1,66 @@
+import ctypes
+
+import pytest
+
+from tests.host_tools import ROOT, compile_c, shared_library_path
+
+
+@pytest.fixture(scope="session")
+def eeprom_driver_library(tmp_path_factory):
+    output_dir = tmp_path_factory.mktemp("eeprom-driver")
+    library = shared_library_path(output_dir, "eeprom_driver")
+    compile_c(
+        output=library,
+        sources=[
+            ROOT / "driver" / "eeprom.c",
+            ROOT / "driver" / "hardware.c",
+            ROOT / "tests" / "host" / "eeprom_driver_harness.c",
+        ],
+        shared=True,
+    )
+
+    loaded = ctypes.CDLL(str(library))
+    loaded.HOST_EepromDriver_Reset.argtypes = [ctypes.c_bool, ctypes.c_bool]
+    loaded.EEPROM_ReadBuffer.argtypes = [
+        ctypes.c_uint16,
+        ctypes.c_void_p,
+        ctypes.c_uint8,
+    ]
+    loaded.EEPROM_ReadBuffer.restype = ctypes.c_bool
+    loaded.EEPROM_WriteBuffer.argtypes = [ctypes.c_uint16, ctypes.c_void_p]
+    loaded.EEPROM_WriteBuffer.restype = ctypes.c_bool
+    loaded.HARDWARE_GetLastFault.restype = ctypes.c_int
+    loaded.HARDWARE_ClearFault.argtypes = []
+    return loaded
+
+
+def test_eeprom_read_success_propagates_data(eeprom_driver_library):
+    lib = eeprom_driver_library
+    output = (ctypes.c_uint8 * 8)()
+    lib.HARDWARE_ClearFault()
+    lib.HOST_EepromDriver_Reset(False, False)
+
+    assert lib.EEPROM_ReadBuffer(0x100, output, len(output))
+    assert list(output) == [0x5A] * len(output)
+    assert lib.HARDWARE_GetLastFault() == 0
+
+
+def test_eeprom_ack_failure_returns_safe_erased_defaults(eeprom_driver_library):
+    lib = eeprom_driver_library
+    output = (ctypes.c_uint8 * 8)(*([0x12] * 8))
+    lib.HARDWARE_ClearFault()
+    lib.HOST_EepromDriver_Reset(True, False)
+
+    assert not lib.EEPROM_ReadBuffer(0x100, output, len(output))
+    assert list(output) == [0xFF] * len(output)
+    assert lib.HARDWARE_GetLastFault() == 5
+
+
+def test_eeprom_data_write_failure_is_reported(eeprom_driver_library):
+    lib = eeprom_driver_library
+    data = (ctypes.c_uint8 * 8)(*range(8))
+    lib.HARDWARE_ClearFault()
+    lib.HOST_EepromDriver_Reset(False, True)
+
+    assert not lib.EEPROM_WriteBuffer(0x100, data)
+    assert lib.HARDWARE_GetLastFault() == 5

--- a/tests/test_hardware_timeout.py
+++ b/tests/test_hardware_timeout.py
@@ -1,0 +1,63 @@
+import ctypes
+
+import pytest
+
+from tests.host_tools import ROOT, compile_c, shared_library_path
+
+
+@pytest.fixture(scope="session")
+def hardware_library(tmp_path_factory):
+    output_dir = tmp_path_factory.mktemp("hardware-timeout")
+    library = shared_library_path(output_dir, "hardware_timeout")
+    compile_c(
+        output=library,
+        sources=[ROOT / "driver" / "hardware.c"],
+        shared=True,
+    )
+
+    loaded = ctypes.CDLL(str(library))
+    loaded.HARDWARE_WaitForRegister.argtypes = [
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+    ]
+    loaded.HARDWARE_WaitForRegister.restype = ctypes.c_bool
+    loaded.HARDWARE_ReportFault.argtypes = [ctypes.c_int]
+    loaded.HARDWARE_GetLastFault.restype = ctypes.c_int
+    loaded.HARDWARE_TakePendingFault.restype = ctypes.c_int
+    loaded.HARDWARE_ClearFault.argtypes = []
+    return loaded
+
+
+def test_register_wait_succeeds_when_mask_matches(hardware_library):
+    register = ctypes.c_uint32(0xA5)
+
+    assert hardware_library.HARDWARE_WaitForRegister(
+        ctypes.byref(register), 0x0F, 0x05, 8
+    )
+
+
+def test_register_wait_times_out_for_stuck_peripheral(hardware_library):
+    register = ctypes.c_uint32(0)
+
+    assert not hardware_library.HARDWARE_WaitForRegister(
+        ctypes.byref(register), 0x01, 0x01, 8
+    )
+    assert not hardware_library.HARDWARE_WaitForRegister(
+        ctypes.byref(register), 0x01, 0x01, 0
+    )
+
+
+def test_fault_latch_preserves_diagnostics_and_consumes_pending_state(hardware_library):
+    lib = hardware_library
+    lib.HARDWARE_ClearFault()
+
+    assert lib.HARDWARE_GetLastFault() == 0
+    assert lib.HARDWARE_TakePendingFault() == 0
+
+    lib.HARDWARE_ReportFault(4)
+    assert lib.HARDWARE_GetLastFault() == 4
+    assert lib.HARDWARE_TakePendingFault() == 4
+    assert lib.HARDWARE_TakePendingFault() == 0
+    assert lib.HARDWARE_GetLastFault() == 4

--- a/ui/main.c
+++ b/ui/main.c
@@ -16,6 +16,7 @@
 
 #include <ctype.h>
 #include <string.h>
+#include "driver/hardware.h"
 #include "driver/st7565.h"
 #include "external/printf/printf.h"
 #include "functions.h"
@@ -109,6 +110,39 @@ void UI_DisplayMain(void)
 	uint8_t i;
 
 	memset(gFrameBuffer, 0, sizeof(gFrameBuffer));
+	if (HARDWARE_GetLastFault() != HARDWARE_FAULT_NONE) {
+		const char *pFault = "UNKNOWN";
+
+		switch (HARDWARE_GetLastFault()) {
+		case HARDWARE_FAULT_ADC:
+			pFault = "ADC TIMEOUT";
+			break;
+		case HARDWARE_FAULT_AES:
+			pFault = "AES TIMEOUT";
+			break;
+		case HARDWARE_FAULT_UART:
+			pFault = "UART TIMEOUT";
+			break;
+		case HARDWARE_FAULT_SPI:
+			pFault = "LCD TIMEOUT";
+			break;
+		case HARDWARE_FAULT_EEPROM:
+			pFault = "EEPROM ERROR";
+			break;
+		case HARDWARE_FAULT_BK4819:
+			pFault = "RADIO TIMEOUT";
+			break;
+		case HARDWARE_FAULT_FLASH:
+			pFault = "FLASH TIMEOUT";
+			break;
+		default:
+			break;
+		}
+		UI_PrintString("HARDWARE ERROR", 0, 127, 2, 8, true);
+		UI_PrintString(pFault, 0, 127, 4, 8, true);
+		ST7565_BlitFullScreen();
+		return;
+	}
 	if (gEeprom.KEY_LOCK && gKeypadLocked) {
 		UI_PrintString("Long Press #", 0, 127, 1, 8, true);
 		UI_PrintString("To Unlock", 0, 127, 3, 8, true);


### PR DESCRIPTION
## Summary
- bound ADC, AES, UART, LCD SPI, BK4819, EEPROM/I2C, and optional flash polling paths
- propagate driver failures and latch subsystem diagnostics instead of hanging
- force a fail-closed radio state that disables TX DSP, PA bias/enable, TX LED, and future TX attempts
- show a persistent hardware error when the LCD remains usable
- document every polling loop and intentionally permanent loop
- add host fault-injection coverage for stuck registers and EEPROM failures

## Validation
- 114 host tests with AddressSanitizer and UndefinedBehaviorSanitizer
- cppcheck and changed-line clang-format checks
- default, `ENABLE_OVERLAY=1`, and `ENABLE_AIRCOPY=1` ARM builds
- reproducible raw and packed firmware builds
- default image: 52,372 bytes (928-byte increase; 122,880-byte CI limit)

## Hardware follow-up
Normal peripheral timing and physical PA-disable behavior remain on the release hardware checklist.

Closes #40