### PR TITLE
Harden release and contribution workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Firmware bug
+description: Report a reproducible firmware, programming, build, or release problem.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for helping make the loaner firmware safer and easier to use.
+  - type: input
+    id: version
+    attributes:
+      label: Firmware version
+      description: Release tag, displayed OEFW suffix, or commit SHA.
+      placeholder: OEFW-LNR2415 or 6839a25
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Radio / RF / transmit
+        - UI / keypad / audio
+        - EEPROM / settings
+        - UART / CHIRP programming
+        - Build / CI / release artifacts
+        - USB / power / charging
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Include the expected behavior and the actual behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      placeholder: |
+        1. Flash ...
+        2. Configure ...
+        3. Press ...
+    validations:
+      required: true
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware and test evidence
+      description: Radio model/revision, cable, battery/power source, instruments, logs, screenshots, and RF observations. Say "not hardware-tested" when applicable.
+  - type: dropdown
+    id: release
+    attributes:
+      label: Release impact
+      options:
+        - Blocks the next release
+        - Should be fixed soon but does not block release
+        - Can wait for a later release
+        - Unsure
+    validations:
+      required: true
+  - type: checkboxes
+    id: responsibility
+    attributes:
+      label: Operating responsibility
+      options:
+        - label: I understand that operators and programmers are responsible for lawful frequencies, power, modes, and equipment use.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Improvement request
+description: Propose a focused firmware, tooling, documentation, or release improvement.
+title: "[Improvement]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: need
+    attributes:
+      label: Problem or operational need
+      description: Describe the user, field, maintenance, or release problem before proposing a solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Explain the smallest useful change and any alternatives considered.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Radio / RF / transmit
+        - UI / keypad / audio
+        - EEPROM / settings
+        - UART / CHIRP programming
+        - Build / CI / release artifacts
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: checkboxes
+    id: validation
+    attributes:
+      label: Expected validation
+      options:
+        - label: This likely needs physical radio testing.
+        - label: This may change firmware size or optional feature builds.
+        - label: This may change CHIRP or EEPROM compatibility.
+        - label: This should be mentioned in release notes.
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List observable outcomes that would make the request complete.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,46 @@
+## Summary
+
+<!-- What changed, why, and which firmware areas are affected? -->
+
+Closes #
+
+## Release impact
+
+- [ ] No user-visible or release impact
+- [ ] User-visible behavior changed; release notes are needed
+- [ ] Release-blocking fix
+- [ ] EEPROM, UART/CHIRP, packed metadata, or version compatibility changed
+
+## Firmware size
+
+<!-- Run a clean ARM build. Use N/A only for documentation-only changes. -->
+
+| Measurement | Bytes |
+| --- | ---: |
+| Before | |
+| After | |
+| Delta | |
+
+## Validation
+
+- [ ] `pytest -q`
+- [ ] changed-line clang-format check
+- [ ] cppcheck
+- [ ] clean ARM build
+- [ ] two-build reproducibility check
+- [ ] CHIRP compatibility checked, or not affected
+
+## Hardware validation
+
+- [ ] Hardware is not required for this change
+- [ ] Hardware testing completed and results are included below
+- [ ] Hardware testing is still required and is tracked in issue #
+
+<!-- Radio model, test steps, expected/actual results, RF observations, logs, or screenshots. -->
+
+## Checklist
+
+- [ ] The PR is focused and linked to its issue
+- [ ] New or changed behavior is documented
+- [ ] Optional `ENABLE_*` configurations touched by this change still build
+- [ ] I reviewed the [contributor guide](../CONTRIBUTING.md) and [release checklist](../docs/release-checklist.md)

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
 
@@ -37,7 +37,7 @@ jobs:
           echo "VERSION_SUFFIX=${SUFFIX}" >> "${GITHUB_ENV}"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
+        uses: github/codeql-action/init@c54b30b7df092240050e69945842bc67aee0f0f4 # v4.37.3
         with:
           languages: ${{ matrix.language }}
 
@@ -48,4 +48,4 @@ jobs:
         run: make -j"$(nproc)"
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
+        uses: github/codeql-action/analyze@c54b30b7df092240050e69945842bc67aee0f0f4 # v4.37.3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12.11'
 
@@ -38,12 +38,12 @@ jobs:
     needs: style
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12.11'
 
@@ -58,7 +58,7 @@ jobs:
     needs: [style, clang-format]
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install cppcheck
         run: |
@@ -73,12 +73,12 @@ jobs:
     needs: [style, clang-format, cppcheck]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.10.18'
 
@@ -130,10 +130,10 @@ jobs:
         python-version: ['3.10.18', '3.12.11']
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -152,7 +152,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           submodules: recursive
@@ -170,7 +170,7 @@ jobs:
         run: ls -l compiled-firmware
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: github.event_name == 'workflow_dispatch'
         with:
           name: loaner-firmware-${{ env.VERSION_SUFFIX }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           submodules: recursive
@@ -58,7 +58,7 @@ jobs:
         run: ls -l compiled-firmware
 
       - name: Upload workflow artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.release.outputs.artifact_stem }}
           path: compiled-firmware/loaner-firmware-*

--- a/.github/workflows/update-chirp-pin.yaml
+++ b/.github/workflows/update-chirp-pin.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12.11'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,12 +10,12 @@
 - `make` (or `win_make.bat`) builds both the raw and required packed firmware; a packing or metadata failure fails the build.
 - `./compile-with-docker.sh` uses the pinned container and checksum-verified GCC 10.3.1 toolchain, proves two clean builds are byte-identical, and writes artifacts to `compiled-firmware/`.
 - `make clean` clears objects before benchmarking size; `make flash`/`make debug` expect OpenOCD with a J-Link config.
-- `python3 fw-pack.py pack loaner-firmware.bin LNR24A5 loaner-firmware.packed.bin` injects metadata; use the `verify` subcommand before publishing an image.
+- `python3 fw-pack.py pack loaner-firmware.bin LNR2415 loaner-firmware.packed.bin` injects metadata; use the `verify` subcommand before publishing an image.
 
 ## Coding Style & Naming Conventions
 - Indent with tabs; macros remain uppercase snake-case (`ENABLE_*`, `SYSCON_*`).
 - Use same-line opening braces for enums and structs, next-line opening braces for functions, and same-line braces for control statements. Declare pointers as `Type *name`, indent initializer elements by one tab, and column-align consecutive assignments.
-- Follow existing naming: module globals use leading capitals (`gScreenLine`), static helpers stay lower_case, and files compile as C11.
+- Follow existing naming: module globals use the `g` prefix (`gScreenLine`), static helpers stay lower_case, and files compile as C11.
 - Order includes from local headers outward and wrap optional code in the matching `#ifdef ENABLE_*` guard.
 - Treat `-Werror` seriously—run `make` locally to keep the build warning-free.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -16,6 +16,17 @@ Run the complete validation and build pipeline with an exact seven-character upp
 VERSION_SUFFIX=LNR2415 ./compile-with-docker.sh
 ```
 
+From Windows Command Prompt with Git for Windows installed, run the same
+pipeline through the batch wrapper:
+
+```bat
+set VERSION_SUFFIX=LNR2415
+compile-with-docker.bat
+```
+
+PowerShell users can set `$env:VERSION_SUFFIX = "LNR2415"` and then run
+`.\compile-with-docker.bat`.
+
 The wrapper runs the formatting check, cppcheck, pytest, and two clean ARM builds. The two raw images and two packed images must be byte-identical before it writes a verified bundle to `compiled-firmware/`:
 
 - `loaner-firmware-LNR2415.bin`
@@ -82,6 +93,10 @@ python3 ci/release_artifacts.py tag-to-suffix v24.10.5
 Before tagging, write the resulting value to the root `VERSION_SUFFIX` file and merge that change. The release workflow requires the file, tag, packed metadata, display banner, UART identifier, artifact names, and manifest to agree.
 
 ## Release Checklist
+
+The concise software, hardware, and publishing gate is maintained in
+[`docs/release-checklist.md`](docs/release-checklist.md). The version/tag steps
+below provide the detailed command sequence.
 
 1. Create a release branch from current `main`.
 2. Pick a `vYY.MM[.PATCH]` tag and derive its suffix.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing
+
+Thanks for improving the loaner firmware. Keep each change focused, link it to
+a GitHub issue, and work on a feature branch rather than `main`.
+
+## Build and test
+
+Docker is the canonical path because it pins the compiler, package snapshot,
+Python dependencies, and formatting tools. From Git Bash, WSL, Linux, or
+macOS:
+
+```sh
+VERSION_SUFFIX=LNR2415 ./compile-with-docker.sh
+```
+
+From Windows Command Prompt:
+
+```bat
+set VERSION_SUFFIX=LNR2415
+compile-with-docker.bat
+```
+
+The full pipeline runs formatting, cppcheck, sanitizer-backed host tests, two
+clean ARM builds, the firmware-size limit, packing, metadata verification, and
+the reproducibility comparison. See [BUILDING.md](BUILDING.md) for native and
+single-test commands.
+
+## Pull requests
+
+Use the pull-request template and include:
+
+- the linked issue and user-visible/release impact;
+- before/after/delta firmware size from a clean build;
+- automated test results and any affected optional `ENABLE_*` builds;
+- whether EEPROM or UART/CHIRP compatibility changed; and
+- hardware steps and results, or a linked `hardware-required` issue naming the
+  remaining test.
+
+Do not report hardware-dependent work as complete based only on host tests.
+RF, PA-disable, charging, USB electrical behavior, audio, and keypad changes
+need the appropriate physical test evidence before release.
+
+## Commits and review
+
+Use short imperative commit subjects. Keep generated binaries and local build
+output out of commits. `main` requires a pull request and all protected CI and
+CodeQL checks; force pushes and branch deletion are disabled.
+
+Before preparing a tag, follow the [release checklist](docs/release-checklist.md).
+
+## Issue triage
+
+Apply one priority and one area label when the scope is clear:
+
+- `priority:p0`, `priority:p1`, or `priority:p2`;
+- `area:firmware`, `area:radio-rf`, `area:ui`, `area:eeprom-chirp`,
+  `area:power-usb`, or `area:build-ci`.
+
+Add `hardware-required` when physical validation remains and
+`release-blocking` only when the issue must be resolved before publishing the
+next firmware release.

--- a/README.md
+++ b/README.md
@@ -76,17 +76,13 @@ Tip: Keep a CHIRP image with the baseline loaner plan in source control so teams
 ## Field Notes
 - Carry one handset that stayed stock as a control; it helps confirm the loader steps when training new volunteers.
 - Log which firmware release you flashed (the welcome banner shows the tag) alongside the ICS-205 so future updates are easy to track.
-- If a user reports odd audio or RF behaviour, power cycle and reseat the battery first; the firmware keeps settings read-only so faults are usually hardware.
+- If a user reports odd audio or RF behaviour, record the firmware suffix and reproduction steps, then power-cycle and reseat the battery before deeper diagnosis.
 
 ## Need to Modify the Firmware?
 All developer-facing build and packaging details live in `BUILDING.md`. Start there if you need to regenerate binaries or adjust feature toggles.
 
 ## Contributing
-Open issues or PRs if you spot regressions that impact the loaner workflow. Documentation updates (especially CHIRP workflows and loaner field notes) are welcome.
-
-## Project Backlog Snapshot
-- `docs/issues/issue-export.json` captures the high-level loaner backlog for offline reference.
-- `docs/issues/issues-detailed.json` preserves the matching GitHub issue metadata export.
+Open issues or PRs if you spot regressions that impact the loaner workflow. See [CONTRIBUTING.md](CONTRIBUTING.md) for the canonical build, validation, firmware-size, CHIRP, and hardware-test requirements.
 
 ## Credits
 Based on the open-source efforts by DualTachyon, OneOfEleven, Fagci, and the wider UV-K5 community. This fork simply repackages their work for the loaner-radio use case.

--- a/ci/dependencies.md
+++ b/ci/dependencies.md
@@ -56,7 +56,7 @@ the two-build firmware comparison.
 
 | Action | Reviewed version | Commit |
 | --- | --- | --- |
-| `actions/checkout` | `v4.4.0` | `11d5960a326750d5838078e36cf38b85af677262` |
-| `actions/setup-python` | `v5.6.0` | `a26af69be951a213d495a4c3e4e4022e16d87065` |
-| `actions/upload-artifact` | `v4.6.2` | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
-| `github/codeql-action` | `v3.37.3` | `4187e74d05793876e9989daffde9c3e66b4acd07` |
+| `actions/checkout` | `v7.0.1` | `3d3c42e5aac5ba805825da76410c181273ba90b1` |
+| `actions/setup-python` | `v7.0.0` | `5fda3b95a4ea91299a34e894583c3862153e4b97` |
+| `actions/upload-artifact` | `v7.0.1` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
+| `github/codeql-action` | `v4.37.3` | `c54b30b7df092240050e69945842bc67aee0f0f4` |

--- a/compile-with-docker.bat
+++ b/compile-with-docker.bat
@@ -1,3 +1,19 @@
 @echo off
-docker build -t uvk5 .
-docker run -v %CD%\compiled-firmware:/app/compiled-firmware uvk5 /bin/bash -c "cd /app && make && cp firmware* compiled-firmware/"
+setlocal
+
+if "%VERSION_SUFFIX%"=="" (
+    echo VERSION_SUFFIX must be set to exactly 7 uppercase letters or digits.
+    echo Example: set VERSION_SUFFIX=LNR2415
+    exit /b 1
+)
+
+set "GIT_BASH=%ProgramFiles%\Git\bin\bash.exe"
+if not exist "%GIT_BASH%" set "GIT_BASH=%LocalAppData%\Programs\Git\bin\bash.exe"
+
+if not exist "%GIT_BASH%" (
+    echo Git Bash was not found. Install Git for Windows or run compile-with-docker.sh from WSL.
+    exit /b 1
+)
+
+"%GIT_BASH%" "%~dp0compile-with-docker.sh"
+exit /b %errorlevel%

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,27 @@
+# Release checklist
+
+## Software gate
+
+- [ ] Every release-blocking issue is closed or explicitly deferred with a reason.
+- [ ] `VERSION_SUFFIX` matches the planned `vYY.MM[.PATCH]` tag mapping.
+- [ ] The canonical Docker pipeline passes from a clean checkout.
+- [ ] CI, CodeQL, CHIRP compatibility, sanitizer tests, and reproducibility checks are green on the release commit.
+- [ ] Raw and packed binaries, manifest, checksums, identifiers, and filenames agree.
+- [ ] Firmware size is recorded and remains below the CI limit.
+- [ ] Release notes cover user-visible behavior, compatibility, and known limitations.
+
+## Hardware gate
+
+- [ ] Boot, display, keypad/knob, speaker/audio, and normal receive are smoke-tested.
+- [ ] Programming and read-back succeed with the pinned CHIRP-compatible path.
+- [ ] PTT, PA disable, power levels, spurious output, and representative band edges pass the RF bench plan.
+- [ ] USB-C charging/current behavior is verified on the intended hardware revisions and cable orientations.
+- [ ] Any optional feature enabled for the release is exercised on hardware.
+- [ ] Results and equipment details are recorded in the linked hardware issues.
+
+## Publish
+
+- [ ] Merge the release-preparation PR and tag that exact `main` commit.
+- [ ] Confirm the automated GitHub release contains the verified four-file bundle.
+- [ ] Download the published assets once and verify the manifest/checksums independently.
+- [ ] Keep the release blocked if a required hardware result is missing or failed.


### PR DESCRIPTION
## Summary

- add structured bug/improvement forms, a PR template, contributor guidance, and a software/hardware/publish release checklist
- repair the Windows Docker wrapper so it runs the same pinned, reproducible pipeline as Unix hosts
- update documentation to match current behavior and remove stale backlog references
- refresh official GitHub Actions to their current immutable release SHAs
- document the issue label taxonomy that will be configured after merge

Refs #45

## Release impact

- [x] No firmware behavior changed
- [x] Build/release governance changed
- [x] Hardware testing is not required for this documentation/tooling change

## Firmware size

| Measurement | Bytes |
| --- | ---: |
| Before | 52,384 |
| After | 52,384 |
| Delta | 0 |

## Validation

- canonical Windows Docker wrapper: pass
- sanitizer-backed host suite: 114 tests passed
- clang-format 14.0.6: pass
- cppcheck: pass
- all firmware configurations: pass
- two-build reproducibility and packed-artifact verification: pass
- actionlint: pass
- issue-form YAML parse: pass
- `python -m ruff check tests ci fw-pack.py`: pass
- local `pytest -q`: 39 passed, 75 skipped because no host C compiler is installed outside Docker
- `git diff --check`: pass

After this PR merges, the repository-side acceptance steps are to create/apply the documented labels and protect `main` with the green CI and CodeQL checks.