### PR TITLE
Remove unreachable key dispatch code

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,6 +1,8 @@
 # Building the Loaner Firmware
 
 This document covers local builds, validation, firmware packing, and releases.
+The default feature choices and rules for removing optional code are recorded
+in [`docs/feature-inventory.md`](docs/feature-inventory.md).
 
 ## Prerequisites
 

--- a/app/main.c
+++ b/app/main.c
@@ -81,8 +81,6 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 	gUpdateStatus = true;
 	switch (Key) {
 	case KEY_4:
-		gWasFKeyPressed = false;
-		gUpdateStatus = true;
 		gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
 		gFlagStartScan = true;
 		gScanSingleFrequency = false;
@@ -92,8 +90,6 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 
 	default:
 		gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
-		gWasFKeyPressed = false;
-		gWasFKeyPressed = false;
 		break;
 	}
 }
@@ -122,24 +118,6 @@ static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
 			gAnotherVoiceID = VOICE_ID_SCANNING_STOP;
 		}
 		gRequestDisplayScreen = DISPLAY_MAIN;
-	}
-}
-
-static void MAIN_Key_MENU(bool bKeyPressed, bool bKeyHeld)
-{
-	if (!bKeyHeld && bKeyPressed) {
-		bool bFlag;
-
-		gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
-		bFlag = gInputBoxIndex == 0;
-		gInputBoxIndex = 0;
-		if (bFlag) {
-			gFlagRefreshSetting = true;
-			gRequestDisplayScreen = DISPLAY_MENU;
-			gAnotherVoiceID = VOICE_ID_MENU;
-		} else {
-			gRequestDisplayScreen = DISPLAY_MAIN;
-		}
 	}
 }
 
@@ -275,19 +253,11 @@ void MAIN_ProcessKeys(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 		}
 	}
 
-	// TODO: ???
-	if (KEY_PTT < Key) {
-		Key = KEY_SIDE2;
-	}
-
 	switch (Key) {
 	case KEY_0: case KEY_1: case KEY_2: case KEY_3:
 	case KEY_4: case KEY_5: case KEY_6: case KEY_7:
 	case KEY_8: case KEY_9:
 		MAIN_Key_DIGITS(Key, bKeyPressed, bKeyHeld);
-		break;
-	case KEY_MENU:
-		MAIN_Key_MENU(bKeyPressed, bKeyHeld);
 		break;
 	case KEY_UP:
 		MAIN_Key_UP_DOWN(bKeyPressed, bKeyHeld, 1);

--- a/docs/feature-inventory.md
+++ b/docs/feature-inventory.md
@@ -1,0 +1,33 @@
+# Firmware feature inventory
+
+This inventory separates the behavior shipped in the default loaner image from
+optional source retained for upstream compatibility. A disabled `ENABLE_*`
+option is not linked into the default image unless the table says otherwise.
+
+| Feature family | Default image | Repository decision | Reason |
+| --- | --- | --- | --- |
+| UART and CHIRP programming | Enabled and linked | Retain | Required to program and clone the loaner channel plan. |
+| Channel and CSS scanning | Linked | Retain | Used to find active channels and tones in the field. |
+| Boot-time maintenance menu | Linked | Retain | Holding Side 1 during boot exposes service and frequency-lock settings. The normal Menu-key entry remains blocked. |
+| DTMF signaling | Linked | Retain | Supports interoperability workflows; removal would need a separate product decision and radio tests. |
+| Voice prompts and battery/RSSI UI | Linked | Retain | Supports loaner usability and field diagnostics. |
+| Aircopy | `ENABLE_AIRCOPY=0`; app/UI objects are not linked | Retain optional source | No default firmware-size cost, while retaining an upstream-compatible option. |
+| FM broadcast receiver | `ENABLE_FMRADIO=0`; app/UI/driver objects are not linked | Retain optional source | No default firmware-size cost, while retaining an upstream-compatible option. |
+| NOAA mode | `ENABLE_NOAA=0`; guarded paths are compiled out | Retain optional source | Disabled in the default loaner image; source deletion would not reduce that image. |
+| Alarm and optional 1750-Hz feature paths | `ENABLE_ALARM=0`, `ENABLE_TX1750=0`; guarded paths are compiled out | Retain optional source | Disabled in the default loaner image; interoperability behavior should not be removed as mechanical cleanup. |
+| SRAM overlay | `ENABLE_OVERLAY=0`; overlay/flash objects are not linked | Retain optional source | Avoids the overlay complexity in the default image without making upstream merges harder. |
+| SWD support | `ENABLE_SWD=0`; guarded support is compiled out | Retain optional source | Not needed in release images, but useful for development builds. |
+
+## Cleanup rule
+
+Delete code only when its path is demonstrably unreachable or a separately
+approved feature-removal issue defines the user impact and hardware validation.
+Do not delete optional source merely to reduce repository file count: the
+linker already excludes disabled object files and guarded paths from the
+default image.
+
+The normal key dispatcher rejects `KEY_MENU` before `MAIN_ProcessKeys`, so the
+old main-screen Menu handler and its switch arm were unreachable. Side-key
+events are handled by `ACTION_Handle` before the same dispatcher, so its legacy
+side-key remap was also ineffective. Those leftovers were removed without
+changing the boot-time maintenance menu or side-key behavior.

--- a/misc.h
+++ b/misc.h
@@ -89,7 +89,6 @@ extern bool gSetting_500TX;
 extern bool gSetting_350EN;
 extern uint8_t gSetting_F_LOCK;
 extern bool gSetting_ScrambleEnable;
-extern uint8_t gSetting_F_LOCK;
 
 extern const uint32_t gDefaultAesKey[4];
 extern uint32_t gCustomAesKey[4];


### PR DESCRIPTION
## Summary

- remove the unreachable main-screen Menu handler; the outer dispatcher already blocks normal Menu-key entry
- remove the ineffective legacy side-key remap; side keys are routed to `ACTION_Handle` before `MAIN_ProcessKeys`
- remove redundant assignments and the duplicate `gSetting_F_LOCK` declaration
- document the default feature inventory and retain CHIRP/UART, boot-time maintenance, scanner, DTMF, voice, and optional upstream source intentionally

Closes #8

## Release impact

- [x] No intended user-visible behavior change
- [x] Firmware cleanup reduces the raw image by 48 bytes
- [x] The broad feature-removal decisions are now explicit
- [x] Release hardware smoke testing is tracked in #56

## Firmware size

| Measurement | Bytes |
| --- | ---: |
| Before | 52,384 |
| After | 52,336 |
| Delta | -48 |

## Validation

- canonical Windows Docker wrapper: pass
- sanitizer-backed host suite: 114 tests passed
- clang-format 14.0.6 changed-line check: pass
- cppcheck: pass
- all firmware configurations: pass
- two-build raw/packed reproducibility: pass
- packed-artifact metadata and manifest verification: pass
- `python -m ruff check tests ci fw-pack.py`: pass
- local `pytest -q`: 39 passed, 75 skipped because the local host lacks a C compiler outside Docker
- `git diff --check`: pass

## Hardware validation

Hardware is deferred to the consolidated next-release qualification in #56, with RF/transmit in #37 and USB-C charging in #46.