### PR TITLE
Use UV Tools for v24.12.5 flashing

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -103,7 +103,9 @@ below provide the detailed command sequence.
 1. Create a release branch from current `main`.
 2. Pick a `vYY.MM[.PATCH]` tag and derive its suffix.
 3. Update `VERSION_SUFFIX`, build with that suffix, and run all checks, including the two-build hash comparison.
-4. Flash the packed image and confirm the displayed version on hardware.
+4. Flash the packed image with the
+   [Egzumer UV Tools web flasher](https://egzumer.github.io/uvtools/) and confirm
+   the displayed version on hardware.
 5. Merge the release preparation PR.
 6. Tag the exact merge commit and push the annotated tag:
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ The project also gives COML/COMT staff a predictable path from the ICS-205 form 
 
 ## Quickstart
 1. Download the latest suffix-bearing packed release (for example `loaner-firmware-LNR24C5.packed.bin`) from the Releases page and, when practical, compare it with the published SHA-256 file.
-2. With the radio powered off, hold the **PTT** and the **top side key** while turning it on. The display should stay blank, indicating the bootloader is active.
-3. Connect the USB cable, open Quansheng's PC programming tool, select *Firmware Update*, point it at the packed image, and start the transfer.
-4. After the loader reports success, power the radio off and back on to confirm the welcome screen shows the release tag from the packed image.
-5. Spin the channel knob and verify that the loaner channel names appear as expected.
+2. Open the [Egzumer UV Tools web flasher](https://egzumer.github.io/uvtools/) in a browser that supports serial-device access, then choose **Select firmware file** and select the packed image.
+3. With the radio powered off, hold the **PTT** and the **top side key** while turning it on. The display should stay blank, indicating the bootloader is active.
+4. Connect the USB programming cable, choose **Flash firmware**, select the radio's serial port if prompted, and do not disconnect power or the cable until the transfer completes.
+5. Power the radio off and back on to confirm the welcome screen shows the release tag from the packed image.
+6. Spin the channel knob and verify that the loaner channel names appear as expected.
 
 ## Design Goals
 - Put channel-only handsets in the hands of volunteers who have minimal or no radio training.
@@ -56,22 +57,15 @@ The current firmware intentionally keeps the OEM-compatible EEPROM layout. If th
 Tip: Keep a CHIRP image with the baseline loaner plan in source control so teams can diff changes before distributing updates. After each upload, rotate the knob and confirm the ICS-205 names match the paperwork.
 
 ## Flashing
-### Quansheng PC Loader (recommended)
-1. Install Quansheng's UV-K5/K6 programming utility if it is not already on your workstation.
-2. Copy the packed binary locally - the metadata is required by Quansheng's loader.
-3. With the radio powered off, hold **PTT** + **top side key** and power it on to enter firmware download mode (the screen remains blank).
-4. Connect the USB cable (CH340 driver) and confirm the loader detects the serial port.
-5. Choose *Firmware Update*, select the packed binary, and start the process. Do not disconnect power until the loader reports completion.
-6. Power-cycle the radio and confirm the loaner splash/version text is displayed.
 
-### J-Link / OpenOCD (`make flash`)
-1. Install OpenOCD and ensure it is configured for a J-Link probe, matching the expectations baked into the repo's OpenOCD config.
-2. Connect the debugger to the radio's programming header.
-3. From the repository root run:
-   ```sh
-   make flash
-   ```
-4. Use `make debug` afterwards if you need an interactive OpenOCD session.
+Use only the [Egzumer UV Tools web flasher](https://egzumer.github.io/uvtools/) for release images:
+
+1. Download the suffix-bearing `*.packed.bin` file from the GitHub release. Do not use the raw `*.bin` file for normal flashing.
+2. Open UV Tools in a browser that supports serial-device access and choose **Select firmware file**.
+3. Select the downloaded packed image.
+4. With the radio powered off, hold **PTT** + **top side key** and power it on. The blank screen indicates firmware download mode.
+5. Connect the USB programming cable and choose **Flash firmware**. Select the radio's serial port if the browser asks for permission.
+6. Leave the radio powered and connected until the transfer completes, then power-cycle it and confirm the loaner splash/version text.
 
 ## Field Notes
 - Carry one handset that stayed stock as a control; it helps confirm the loader steps when training new volunteers.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -18,10 +18,11 @@
 - [ ] USB-C charging/current behavior is verified on the intended hardware revisions and cable orientations.
 - [ ] Any optional feature enabled for the release is exercised on hardware.
 - [ ] Results and equipment details are recorded in the linked hardware issues.
+- [ ] Any incomplete result is explicitly deferred by the release owner with its reason, risk, and follow-up issue recorded in the release notes.
 
 ## Publish
 
 - [ ] Merge the release-preparation PR and tag that exact `main` commit.
 - [ ] Confirm the automated GitHub release contains the verified four-file bundle.
 - [ ] Download the published assets once and verify the manifest/checksums independently.
-- [ ] Keep the release blocked if a required hardware result is missing or failed.
+- [ ] Keep the release blocked if a required hardware result is missing or failed and has not been explicitly deferred and documented by the release owner.

--- a/docs/releases/LNR24C5.md
+++ b/docs/releases/LNR24C5.md
@@ -39,10 +39,27 @@ and release-process work merged since `v24.12.4`.
 - `loaner-firmware-LNR24C5.manifest.json`
 - `loaner-firmware-LNR24C5.sha256`
 
-## Hardware release gates
+## Flashing
 
-Do not publish the release until the results are recorded and accepted in:
+Flash the suffix-bearing packed image with the
+[Egzumer UV Tools web flasher](https://egzumer.github.io/uvtools/). Select the
+`loaner-firmware-LNR24C5.packed.bin` asset, put the radio into firmware download
+mode, and choose **Flash firmware**. Do not use the raw `.bin` asset for normal
+flashing.
+
+## Hardware validation status
+
+The release owner confirmed successful GMRS transmit on the final functional
+firmware candidate, commit `1ed32cc` (`LNR24C5`, packed SHA-256
+`8fc0672fdbb320332843fa865a7b34c34f1dc5f98b429a4c4f7b0884cac7b191`). The
+release-tag commit adds documentation only; the firmware source and build
+configuration are unchanged from that tested candidate.
+
+The release owner explicitly deferred the following broader checks for this
+release. They remain open follow-up work and are not represented as passing:
 
 - #56 — complete radio hardware qualification;
 - #37 — unlocked-band RF/transmit bench validation; and
-- #46 — USB-C charging and charging-current diagnosis.
+- #46 — USB-C charging and charging-current diagnosis. The firmware audit found
+  no charger-enable/control output, so physical charging failure remains a
+  hardware-path investigation unless new evidence shows otherwise.

--- a/docs/releases/LNR24C5.md
+++ b/docs/releases/LNR24C5.md
@@ -58,8 +58,16 @@ configuration are unchanged from that tested candidate.
 The release owner explicitly deferred the following broader checks for this
 release. They remain open follow-up work and are not represented as passing:
 
-- #56 — complete radio hardware qualification;
-- #37 — unlocked-band RF/transmit bench validation; and
-- #46 — USB-C charging and charging-current diagnosis. The firmware audit found
-  no charger-enable/control output, so physical charging failure remains a
-  hardware-path investigation unless new evidence shows otherwise.
+- #56 — complete radio hardware qualification is deferred so the release can
+  proceed after the primary GMRS transmit path passed. Accepted risk: untested
+  boot, display, keypad, audio, receive, and programming paths may still contain
+  hardware-only regressions.
+- #37 — full unlocked-band RF/transmit bench validation is deferred because the
+  completed hardware check covered GMRS transmit only. Accepted risk: output
+  power, PA-disable behavior, harmonics, spurious output, and band-edge behavior
+  outside that test remain unverified and must not be inferred from this release.
+- #46 — USB-C charging and charging-current diagnosis is deferred because the
+  firmware audit found no charger-enable/control output and the remaining work
+  is a hardware-path investigation. Accepted risk: affected radios may still
+  fail to charge over USB or may report charging current incorrectly; users
+  should not rely on USB charging until that issue is validated.


### PR DESCRIPTION
## Summary
- make the Egzumer UV Tools web flasher the only documented release-flashing path
- record successful GMRS transmit on the final functional candidate
- explicitly defer the broader hardware checks in #37, #46, and #56 while keeping them open
- document the release-owner deferral rule in the release checklist

## Validation
- `python -m pytest -q` — 40 passed, 75 skipped
- `python -m ruff check fw-pack.py ci tests` — passed
- `python ci/release_artifacts.py tag-to-suffix v24.12.5` — `LNR24C5`
- `git diff --check` — passed
- visually inspected https://egzumer.github.io/uvtools/ and confirmed the documented **Select firmware file** / **Flash firmware** controls

## Release impact
Documentation-only change. Firmware source, build configuration, EEPROM layout, UART/CHIRP compatibility, and binary size are unchanged from candidate `1ed32cc`. The release build will carry the final tagged commit identity in its manifest/version metadata.

Hardware status: GMRS transmit confirmed by the release owner. The broader RF bench, general hardware qualification, and USB charging investigation remain open and are not represented as passing.